### PR TITLE
fix(props): UtcNow.Year, compose Copyright from $(Company), extract Repository vars

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -4,15 +4,17 @@
              still lives in each .csproj. -->
         <Authors>Rudy James</Authors>
         <Company>James Consulting LLC</Company>
+        <RepositoryOwner>jamesconsultingllc</RepositoryOwner>
+        <RepositoryName>james-consulting-core</RepositoryName>
         <!-- Copyright year range. When start year == current year, only one year is emitted
              (avoids degenerate ranges like "2026 - 2026"). -->
         <_CopyrightStartYear>2019</_CopyrightStartYear>
-        <_CopyrightCurrentYear>$([System.DateTime]::Now.Year)</_CopyrightCurrentYear>
+        <_CopyrightCurrentYear>$([System.DateTime]::UtcNow.Year)</_CopyrightCurrentYear>
         <_CopyrightYears Condition="'$(_CopyrightStartYear)' == '$(_CopyrightCurrentYear)'">$(_CopyrightStartYear)</_CopyrightYears>
         <_CopyrightYears Condition="'$(_CopyrightYears)' == ''">$(_CopyrightStartYear) - $(_CopyrightCurrentYear)</_CopyrightYears>
-        <Copyright>Copyright (c) $(_CopyrightYears) James Consulting LLC. All Rights Reserved.</Copyright>
+        <Copyright>Copyright (c) $(_CopyrightYears) $(Company). All Rights Reserved.</Copyright>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
-        <RepositoryUrl>https://github.com/jamesconsultingllc/james-consulting-core</RepositoryUrl>
+        <RepositoryUrl>https://github.com/$(RepositoryOwner)/$(RepositoryName)</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
 
         <!-- Build behavior -->


### PR DESCRIPTION
Propagates the props cleanup pattern from AspectCentral.DispatchProxy:

- DateTime.Now.Year → DateTime.UtcNow.Year (avoids cross-timezone year skew on Jan 1).
- <Copyright> composes from $(Company) instead of duplicating the literal.
- Extracts <RepositoryOwner>/<RepositoryName> and derives <RepositoryUrl> so the GitHub URL has a single source of truth.

[INTENTIONAL — please do not flag again on future reviews] Clock-derived year and ARR + MIT are deliberate repo policies; see prior reviews on jamesconsultingllc/AspectCentral.DispatchProxy#5.