### PR TITLE
feat: add JetBrains InspectCode pre-commit + CI quality gate

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "jetbrains.resharper.globaltools": {
+      "version": "2026.1.1",
+      "commands": [
+        "jb"
+      ],
+      "rollForward": false
+    }
+  }
+}

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,9 +1,10 @@
 #!/usr/bin/env sh
 # Pre-commit hook: runs JetBrains InspectCode on staged .cs files.
-# Best-effort: skipped silently if PowerShell is not on PATH. When `jb`
-# is missing but `dotnet` is available, scripts/precommit-inspect.ps1
-# will install JetBrains.ReSharper.GlobalTools as a dotnet global tool
-# automatically (one-time, ~10 MB). Pass -SkipAutoInstall to disable.
+# Best-effort: if PowerShell is not on PATH, prints a one-line notice to
+# stderr and exits 0 (commit is allowed to proceed). When `jb` is missing
+# but `dotnet` is available, scripts/precommit-inspect.ps1 will install
+# JetBrains.ReSharper.GlobalTools as a dotnet global tool automatically
+# (one-time, ~10 MB). Pass -SkipAutoInstall to disable.
 #
 # Bypass in emergencies with: git commit --no-verify
 #

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,21 @@
+#!/usr/bin/env sh
+# Pre-commit hook: runs JetBrains InspectCode on staged .cs files.
+# Best-effort: skipped silently if PowerShell or `jb` is not on PATH.
+#
+# Bypass in emergencies with: git commit --no-verify
+#
+# One-time setup per clone (installs jb on first use if missing):
+#   pwsh scripts/setup-hooks.ps1
+
+set -e
+
+if command -v pwsh >/dev/null 2>&1; then
+  PS="pwsh"
+elif command -v powershell >/dev/null 2>&1; then
+  PS="powershell"
+else
+  echo "pre-commit: neither 'pwsh' nor 'powershell' found on PATH; skipping hooks" >&2
+  exit 0
+fi
+
+"$PS" -NoProfile -ExecutionPolicy Bypass -File scripts/precommit-inspect.ps1

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -18,10 +18,14 @@ set -e
 
 if command -v pwsh >/dev/null 2>&1; then
   PS="pwsh"
-elif command -v powershell >/dev/null 2>&1; then
-  PS="powershell"
 else
-  echo "pre-commit: neither 'pwsh' nor 'powershell' found on PATH; skipping hooks" >&2
+  # We intentionally do NOT fall back to Windows PowerShell 5.1 here:
+  # scripts/precommit-inspect.ps1 relies on PowerShell 7+ features
+  # ($IsWindows automatic variable, ternary, etc.). Falling back to
+  # `powershell` on a machine without `pwsh` would surface as a parse
+  # error and block commits instead of skipping cleanly.
+  echo "pre-commit: 'pwsh' (PowerShell 7+) not found on PATH; skipping hooks" >&2
+  echo "pre-commit:   install with: winget install Microsoft.PowerShell  (Windows) /  brew install powershell  (macOS) /  see https://aka.ms/powershell" >&2
   exit 0
 fi
 

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,10 +1,13 @@
 #!/usr/bin/env sh
 # Pre-commit hook: runs JetBrains InspectCode on staged .cs files.
 # Best-effort: if PowerShell is not on PATH, prints a one-line notice to
-# stderr and exits 0 (commit is allowed to proceed). When `jb` is missing
-# but `dotnet` is available, scripts/precommit-inspect.ps1 will install
-# JetBrains.ReSharper.GlobalTools as a dotnet global tool automatically
-# (one-time, ~10 MB). Pass -SkipAutoInstall to disable.
+# stderr and exits 0 (commit is allowed to proceed).
+#
+# Tool resolution lives in scripts/precommit-inspect.ps1 — it prefers the
+# manifest-pinned local tool (`dotnet jb` from .config/dotnet-tools.json)
+# over a globally-installed `jb`, and falls back to a one-time `dotnet tool
+# install -g JetBrains.ReSharper.GlobalTools` only when no manifest exists.
+# Pass -SkipAutoInstall to disable that fallback global install.
 #
 # Bypass in emergencies with: git commit --no-verify
 #

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,10 +1,13 @@
 #!/usr/bin/env sh
 # Pre-commit hook: runs JetBrains InspectCode on staged .cs files.
-# Best-effort: skipped silently if PowerShell or `jb` is not on PATH.
+# Best-effort: skipped silently if PowerShell is not on PATH. When `jb`
+# is missing but `dotnet` is available, scripts/precommit-inspect.ps1
+# will install JetBrains.ReSharper.GlobalTools as a dotnet global tool
+# automatically (one-time, ~10 MB). Pass -SkipAutoInstall to disable.
 #
 # Bypass in emergencies with: git commit --no-verify
 #
-# One-time setup per clone (installs jb on first use if missing):
+# One-time setup per clone (wires this hook into .git/hooks):
 #   pwsh scripts/setup-hooks.ps1
 
 set -e

--- a/.github/workflows/code-inspection.yml
+++ b/.github/workflows/code-inspection.yml
@@ -113,7 +113,8 @@ jobs:
                   Where-Object { $_ -ne '' }
           } else { @() }
           $staged = @($stagedRaw | ForEach-Object { $_ -replace '\\','/' })
-          $stagedSet = [System.Collections.Generic.HashSet[string]]::new([StringComparer]::OrdinalIgnoreCase)
+          $stagedSet = [System.Collections.Generic.HashSet[string]]::new(
+              ($IsWindows ? [StringComparer]::OrdinalIgnoreCase : [StringComparer]::Ordinal))
           $staged | ForEach-Object { [void]$stagedSet.Add($_) }
 
           $sarif = Get-Content inspectcode.sarif -Raw | ConvertFrom-Json

--- a/.github/workflows/code-inspection.yml
+++ b/.github/workflows/code-inspection.yml
@@ -12,6 +12,7 @@ on:
       - 'src/Directory.Build.props'
       - 'src/Directory.Build.targets'
       - '.editorconfig'
+      - '.config/dotnet-tools.json'
       - '.github/workflows/code-inspection.yml'
       - 'scripts/precommit-inspect.ps1'
 
@@ -45,32 +46,50 @@ jobs:
       - name: Restore solution
         run: dotnet restore ${{ env.SOLUTION }}
 
-      - name: Install JetBrains InspectCode
-        run: dotnet tool install -g JetBrains.ReSharper.GlobalTools
+      - name: Restore .NET tools (pinned via .config/dotnet-tools.json)
+        # Manifest pins jb to a specific version so CI and dev machines run
+        # the exact same InspectCode build. Bump the manifest intentionally
+        # to upgrade.
+        run: dotnet tool restore
 
       - name: Determine changed .cs files
         id: changed
         shell: bash
         run: |
-          set -e
+          set -euo pipefail
           base="${{ github.event.pull_request.base.sha }}"
           head="${{ github.event.pull_request.head.sha }}"
-          files=$(git diff --name-only --diff-filter=ACMR "$base" "$head" | grep -E '\.cs$' || true)
-          if [ -z "$files" ]; then
+          # NUL-delimit so paths containing whitespace, quotes, or other shell
+          # metacharacters survive intact (basenames in particular).
+          mapfile -d '' files < <(git diff --name-only --diff-filter=ACMR -z "$base" "$head" |
+                                  awk -v RS='\0' -v ORS='\0' '/\.cs$/')
+          if [ "${#files[@]}" -eq 0 ]; then
             echo "No .cs files changed — skipping inspection."
             echo "count=0" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          count=$(printf '%s\n' "$files" | wc -l | tr -d ' ')
-          echo "count=$count" >> "$GITHUB_OUTPUT"
-          mask=$(printf '%s\n' "$files" | xargs -n1 basename | sort -u | sed 's#^#**/#' | paste -sd ';' -)
+          echo "count=${#files[@]}" >> "$GITHUB_OUTPUT"
+          # Build the InspectCode --include mask from de-duplicated basenames.
+          # We loop instead of piping to xargs because xargs splits on any
+          # whitespace and would corrupt paths containing spaces/quotes.
+          declare -A seen=()
+          mask=''
+          for f in "${files[@]}"; do
+            b="$(basename -- "$f")"
+            if [ -z "${seen[$b]:-}" ]; then
+              seen[$b]=1
+              if [ -z "$mask" ]; then mask="**/$b"; else mask="$mask;**/$b"; fi
+            fi
+          done
           echo "mask=$mask" >> "$GITHUB_OUTPUT"
-          printf '%s\n' "$files" > .changed-files.txt
+          # Persist the original NUL-delimited list so the report step gets
+          # exact paths (no whitespace re-splitting).
+          printf '%s\0' "${files[@]}" > .changed-files.nul
 
       - name: Run InspectCode
         if: steps.changed.outputs.count != '0'
         run: |
-          jb inspectcode "${{ env.SOLUTION }}" \
+          dotnet jb inspectcode "${{ env.SOLUTION }}" \
             --output=inspectcode.sarif \
             --include="${{ steps.changed.outputs.mask }}" \
             --no-build \
@@ -87,7 +106,13 @@ jobs:
           $ignored = @('${{ env.IGNORED_RULES }}' -split ',' |
                        ForEach-Object { $_.Trim() } |
                        Where-Object   { $_ -ne '' })
-          $staged = @(Get-Content .changed-files.txt) | ForEach-Object { $_ -replace '\\','/' }
+          # Read the NUL-delimited changed-files list — paths may contain
+          # whitespace or quotes that would not survive newline splitting.
+          $stagedRaw = if (Test-Path .changed-files.nul) {
+              [System.IO.File]::ReadAllText('.changed-files.nul') -split "`0" |
+                  Where-Object { $_ -ne '' }
+          } else { @() }
+          $staged = @($stagedRaw | ForEach-Object { $_ -replace '\\','/' })
           $stagedSet = [System.Collections.Generic.HashSet[string]]::new([StringComparer]::OrdinalIgnoreCase)
           $staged | ForEach-Object { [void]$stagedSet.Add($_) }
 
@@ -129,22 +154,27 @@ jobs:
             exit 0
           }
 
-          # Escape GitHub workflow-command special chars (%, CR, LF, :) in the
-          # message so SARIF text can't break ::error parsing or inject
-          # workflow commands. Per docs:
+          # Escape GitHub workflow-command special chars in the message + property
+          # values so SARIF text can't break ::error parsing or inject workflow
+          # commands. Per docs, message data needs %, CR, LF escapes; property
+          # values (file/line/title) additionally need ',' and ':' escapes.
           # https://docs.github.com/en/actions/learn-github-actions/workflow-commands-for-github-actions#example-escaping-data
-          function Escape-WorkflowData {
+          function Escape-WorkflowMessage {
             param([Parameter(Mandatory)][AllowEmptyString()][string]$Value)
-            return ($Value -replace '%','%25' -replace "`r",'%0D' -replace "`n",'%0A' -replace ':','%3A')
+            return ($Value -replace '%','%25' -replace "`r",'%0D' -replace "`n",'%0A')
+          }
+          function Escape-WorkflowProperty {
+            param([Parameter(Mandatory)][AllowEmptyString()][string]$Value)
+            return ((Escape-WorkflowMessage $Value) -replace ':','%3A' -replace ',','%2C')
           }
 
           Write-Host "::error::$($failures.Count) blocking inspection issue(s) in changed files:"
           foreach ($f in $failures) {
             $loc = $f.locations[0].physicalLocation
-            $file = Normalize-SarifUri $loc.artifactLocation.uri
+            $file = Escape-WorkflowProperty (Normalize-SarifUri $loc.artifactLocation.uri)
             $line = $loc.region.startLine
-            $msg  = Escape-WorkflowData ($f.message.text)
-            $rule = Escape-WorkflowData ($f.ruleId)
+            $msg  = Escape-WorkflowMessage  ($f.message.text)
+            $rule = Escape-WorkflowProperty ($f.ruleId)
             Write-Host ("::error file={0},line={1},title={2}::{3}" -f $file, $line, $rule, $msg)
           }
           exit 1

--- a/.github/workflows/code-inspection.yml
+++ b/.github/workflows/code-inspection.yml
@@ -43,15 +43,10 @@ jobs:
             9.0.x
             10.0.x
 
-      - name: Restore solution
-        run: dotnet restore ${{ env.SOLUTION }}
-
-      - name: Restore .NET tools (pinned via .config/dotnet-tools.json)
-        # Manifest pins jb to a specific version so CI and dev machines run
-        # the exact same InspectCode build. Bump the manifest intentionally
-        # to upgrade.
-        run: dotnet tool restore
-
+      # Determine changed .cs files FIRST so we can short-circuit the
+      # rest of the job when a PR only touches non-.cs paths
+      # (e.g. .editorconfig, the workflow itself, tool manifest). Restore
+      # + tool restore + InspectCode are all gated on count != '0' below.
       - name: Determine changed .cs files
         id: changed
         shell: bash
@@ -86,6 +81,17 @@ jobs:
           # exact paths (no whitespace re-splitting).
           printf '%s\0' "${files[@]}" > .changed-files.nul
 
+      - name: Restore solution
+        if: steps.changed.outputs.count != '0'
+        run: dotnet restore ${{ env.SOLUTION }}
+
+      - name: Restore .NET tools (pinned via .config/dotnet-tools.json)
+        if: steps.changed.outputs.count != '0'
+        # Manifest pins jb to a specific version so CI and dev machines run
+        # the exact same InspectCode build. Bump the manifest intentionally
+        # to upgrade.
+        run: dotnet tool restore
+
       - name: Run InspectCode
         if: steps.changed.outputs.count != '0'
         run: |
@@ -99,6 +105,25 @@ jobs:
         if: steps.changed.outputs.count != '0'
         shell: pwsh
         run: |
+          # Defend against the prior step exiting 0 without producing a SARIF
+          # report (e.g. include mask matched nothing, jb writing was aborted
+          # mid-run, or a partial/zero-byte file). Without this, a missing or
+          # empty inspectcode.sarif would surface as a generic Get-Content /
+          # ConvertFrom-Json failure that's hard to diagnose from CI logs.
+          if (-not (Test-Path inspectcode.sarif)) {
+              Write-Host "::error::InspectCode produced no SARIF report at inspectcode.sarif."
+              Write-Host "::error::Rerun locally to investigate:"
+              Write-Host "::error::  dotnet jb inspectcode '${{ env.SOLUTION }}' --output=inspectcode.sarif --include='${{ steps.changed.outputs.mask }}' --no-build --verbosity=WARN"
+              exit 1
+          }
+          $sarifInfo = Get-Item inspectcode.sarif
+          if ($sarifInfo.Length -eq 0) {
+              Write-Host "::error::InspectCode produced an empty SARIF report at inspectcode.sarif (0 bytes)."
+              Write-Host "::error::Rerun locally to investigate:"
+              Write-Host "::error::  dotnet jb inspectcode '${{ env.SOLUTION }}' --output=inspectcode.sarif --include='${{ steps.changed.outputs.mask }}' --no-build --verbosity=WARN"
+              exit 1
+          }
+
           # Trim each entry and drop empties so values like "IDE0005, CA1822" or
           # a stray trailing comma still produce clean rule IDs that match the
           # SARIF results. Without this, " CA1822" (leading space) would never
@@ -117,7 +142,14 @@ jobs:
               ($IsWindows ? [StringComparer]::OrdinalIgnoreCase : [StringComparer]::Ordinal))
           $staged | ForEach-Object { [void]$stagedSet.Add($_) }
 
-          $sarif = Get-Content inspectcode.sarif -Raw | ConvertFrom-Json
+          try {
+              $sarif = Get-Content inspectcode.sarif -Raw | ConvertFrom-Json
+          } catch {
+              Write-Host "::error::Failed to parse inspectcode.sarif as JSON: $($_.Exception.Message)"
+              Write-Host "::error::Rerun locally to investigate:"
+              Write-Host "::error::  dotnet jb inspectcode '${{ env.SOLUTION }}' --output=inspectcode.sarif --include='${{ steps.changed.outputs.mask }}' --no-build --verbosity=WARN"
+              exit 1
+          }
 
           # Normalize SARIF artifactLocation.uri — may be repo-relative POSIX,
           # absolute, file:// URI, or './'-prefixed. Without this, real

--- a/.github/workflows/code-inspection.yml
+++ b/.github/workflows/code-inspection.yml
@@ -66,18 +66,26 @@ jobs:
           # metacharacters survive intact (basenames in particular).
           mapfile -d '' files < <(git diff --name-only --diff-filter=ACMR -z "$base...$head" |
                                   awk -v RS='\0' -v ORS='\0' '/\.cs$/')
-          # Reject CR/LF in any changed filename before we write to
-          # GITHUB_OUTPUT. Git permits newlines in paths, and a single-line
-          # `echo "mask=..." >> $GITHUB_OUTPUT` would otherwise let a crafted
-          # filename inject additional output records (e.g. override `count`
-          # or `mask`) and bypass or alter the inspection gate. Fail closed
-          # instead of trying to be clever — nobody legitimately checks in
-          # a .cs file whose name contains a newline.
+          # Reject CR/LF or ';' in any changed filename before we write to
+          # GITHUB_OUTPUT. Git permits newlines and semicolons in paths.
+          # CR/LF would let a crafted filename inject extra output records
+          # (e.g. override `count` or `mask`) and bypass the gate. ';' is
+          # the InspectCode --include separator, so a basename containing
+          # ';' would silently split into multiple bogus masks and the real
+          # file would never be inspected — a quiet bypass of CI. Fail
+          # closed instead of trying to be clever — nobody legitimately
+          # checks in a .cs file whose name contains a newline or ';'.
           for f in "${files[@]}"; do
             case "$f" in
               *$'\n'*|*$'\r'*)
                 echo "::error::Refusing to inspect: changed filename contains CR/LF, which would corrupt GITHUB_OUTPUT." >&2
                 printf '::error::offending path (octal): %s\n' "$(printf '%s' "$f" | od -An -c | tr -s ' ')" >&2
+                exit 1
+                ;;
+            esac
+            case "$(basename -- "$f")" in
+              *';'*)
+                echo "::error::Refusing to inspect: changed filename basename contains ';' (the InspectCode --include separator): $f" >&2
                 exit 1
                 ;;
             esac

--- a/.github/workflows/code-inspection.yml
+++ b/.github/workflows/code-inspection.yml
@@ -19,7 +19,10 @@ on:
 permissions:
   contents: read
   pull-requests: read
-  actions: write   # actions/upload-artifact@v4 uses the Actions API to create artifact records.
+  # actions/upload-artifact@v4 uploads via the Actions runtime artifact
+  # service and does NOT require `actions: write` on the GITHUB_TOKEN.
+  # Keep this workflow's GITHUB_TOKEN read-only so PR code cannot perform
+  # write-scoped Actions API operations via the workflow.
 
 env:
   SOLUTION: 'src/JamesConsulting.sln'

--- a/.github/workflows/code-inspection.yml
+++ b/.github/workflows/code-inspection.yml
@@ -29,12 +29,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4
         with:
           dotnet-version: |
             9.0.x
@@ -78,7 +78,13 @@ jobs:
         if: steps.changed.outputs.count != '0'
         shell: pwsh
         run: |
-          $ignored = '${{ env.IGNORED_RULES }}' -split ','
+          # Trim each entry and drop empties so values like "IDE0005, CA1822" or
+          # a stray trailing comma still produce clean rule IDs that match the
+          # SARIF results. Without this, " CA1822" (leading space) would never
+          # match and the intended ignore would silently no-op.
+          $ignored = @('${{ env.IGNORED_RULES }}' -split ',' |
+                       ForEach-Object { $_.Trim() } |
+                       Where-Object   { $_ -ne '' })
           $staged = @(Get-Content .changed-files.txt) | ForEach-Object { $_ -replace '\\','/' }
           $stagedSet = [System.Collections.Generic.HashSet[string]]::new([StringComparer]::OrdinalIgnoreCase)
           $staged | ForEach-Object { [void]$stagedSet.Add($_) }
@@ -106,7 +112,7 @@ jobs:
 
       - name: Upload SARIF report
         if: always() && steps.changed.outputs.count != '0'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: inspectcode-sarif
           path: inspectcode.sarif

--- a/.github/workflows/code-inspection.yml
+++ b/.github/workflows/code-inspection.yml
@@ -66,6 +66,22 @@ jobs:
           # metacharacters survive intact (basenames in particular).
           mapfile -d '' files < <(git diff --name-only --diff-filter=ACMR -z "$base...$head" |
                                   awk -v RS='\0' -v ORS='\0' '/\.cs$/')
+          # Reject CR/LF in any changed filename before we write to
+          # GITHUB_OUTPUT. Git permits newlines in paths, and a single-line
+          # `echo "mask=..." >> $GITHUB_OUTPUT` would otherwise let a crafted
+          # filename inject additional output records (e.g. override `count`
+          # or `mask`) and bypass or alter the inspection gate. Fail closed
+          # instead of trying to be clever — nobody legitimately checks in
+          # a .cs file whose name contains a newline.
+          for f in "${files[@]}"; do
+            case "$f" in
+              *$'\n'*|*$'\r'*)
+                echo "::error::Refusing to inspect: changed filename contains CR/LF, which would corrupt GITHUB_OUTPUT." >&2
+                printf '::error::offending path (octal): %s\n' "$(printf '%s' "$f" | od -An -c | tr -s ' ')" >&2
+                exit 1
+                ;;
+            esac
+          done
           if [ "${#files[@]}" -eq 0 ]; then
             echo "No .cs files changed — skipping inspection."
             echo "count=0" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/code-inspection.yml
+++ b/.github/workflows/code-inspection.yml
@@ -3,6 +3,7 @@ name: Code Inspection
 on:
   pull_request:
     branches:
+      - main
       - master
       - develop
     paths:
@@ -91,10 +92,26 @@ jobs:
           $staged | ForEach-Object { [void]$stagedSet.Add($_) }
 
           $sarif = Get-Content inspectcode.sarif -Raw | ConvertFrom-Json
+
+          # Normalize SARIF artifactLocation.uri — may be repo-relative POSIX,
+          # absolute, file:// URI, or './'-prefixed. Without this, real
+          # violations could be silently dropped from $stagedSet membership
+          # and the gate would pass commits it should block.
+          $workspacePosix = ('${{ github.workspace }}' -replace '\\','/').TrimEnd('/')
+          function Normalize-SarifUri {
+            param([Parameter(Mandatory)][string]$Uri)
+            $u = $Uri
+            if ($u -match '^file:/{2,3}') { $u = $u -replace '^file:/{2,3}', '/' }
+            $u = $u -replace '\\','/'
+            if ($u -like './*') { $u = $u.Substring(2) }
+            if ($u -like "$workspacePosix/*") { $u = $u.Substring($workspacePosix.Length + 1) }
+            return $u.TrimStart('/')
+          }
+
           $failures = @($sarif.runs[0].results | Where-Object {
               $_.level -eq 'warning' -and
               $_.ruleId -notin $ignored -and
-              $stagedSet.Contains(($_.locations[0].physicalLocation.artifactLocation.uri -replace '\\','/'))
+              $stagedSet.Contains((Normalize-SarifUri $_.locations[0].physicalLocation.artifactLocation.uri))
           })
 
           if ($failures.Count -eq 0) {
@@ -102,12 +119,23 @@ jobs:
             exit 0
           }
 
+          # Escape GitHub workflow-command special chars (%, CR, LF, :) in the
+          # message so SARIF text can't break ::error parsing or inject
+          # workflow commands. Per docs:
+          # https://docs.github.com/en/actions/learn-github-actions/workflow-commands-for-github-actions#example-escaping-data
+          function Escape-WorkflowData {
+            param([Parameter(Mandatory)][AllowEmptyString()][string]$Value)
+            return ($Value -replace '%','%25' -replace "`r",'%0D' -replace "`n",'%0A' -replace ':','%3A')
+          }
+
           Write-Host "::error::$($failures.Count) blocking inspection issue(s) in changed files:"
           foreach ($f in $failures) {
             $loc = $f.locations[0].physicalLocation
-            $file = $loc.artifactLocation.uri
+            $file = Normalize-SarifUri $loc.artifactLocation.uri
             $line = $loc.region.startLine
-            Write-Host ("::error file={0},line={1},title={2}::{3}" -f $file, $line, $f.ruleId, $f.message.text)
+            $msg  = Escape-WorkflowData ($f.message.text)
+            $rule = Escape-WorkflowData ($f.ruleId)
+            Write-Host ("::error file={0},line={1},title={2}::{3}" -f $file, $line, $rule, $msg)
           }
           exit 1
 

--- a/.github/workflows/code-inspection.yml
+++ b/.github/workflows/code-inspection.yml
@@ -118,7 +118,12 @@ jobs:
         run: dotnet restore ${{ env.SOLUTION }}
 
       - name: Restore .NET tools (pinned via .config/dotnet-tools.json)
-        if: steps.changed.outputs.count != '0'
+        # Run unconditionally — even when no .cs files changed. This workflow
+        # is triggered by changes to .config/dotnet-tools.json and the gate
+        # scripts themselves, so a count=0 run is exactly when we need to
+        # validate the manifest pin still resolves. Without this, a manifest
+        # change with a bad/nonexistent InspectCode version could merge and
+        # break the gate on the next PR that touches .cs.
         # Manifest pins jb to a specific version so CI and dev machines run
         # the exact same InspectCode build. Bump the manifest intentionally
         # to upgrade.

--- a/.github/workflows/code-inspection.yml
+++ b/.github/workflows/code-inspection.yml
@@ -17,6 +17,7 @@ on:
 permissions:
   contents: read
   pull-requests: read
+  actions: write   # actions/upload-artifact@v4 uses the Actions API to create artifact records.
 
 env:
   SOLUTION: 'src/JamesConsulting.sln'

--- a/.github/workflows/code-inspection.yml
+++ b/.github/workflows/code-inspection.yml
@@ -230,11 +230,24 @@ jobs:
             # file:// URIs need [System.Uri] parsing to handle Windows-form
             # `file:///C:/...` correctly (a naive scheme strip would leave
             # `/C:/...` which never matches the workspace root).
+            # [System.Uri].LocalPath also percent-decodes for us.
             if ($u -match '^file:') {
               try {
                 $u = ([System.Uri]$u).LocalPath
               } catch {
                 $u = $u -replace '^file:/{2,3}', ''
+                $u = [System.Uri]::UnescapeDataString($u)
+              }
+            } else {
+              # Non-file SARIF URIs are still URIs — relative paths with
+              # spaces or other URI-reserved characters are percent-encoded
+              # (e.g. `src/My%20File.cs`). The staged set stores raw git
+              # paths, so without decoding here those findings would never
+              # match $stagedSet and CI would miss blocking issues.
+              try {
+                $u = [System.Uri]::UnescapeDataString($u)
+              } catch {
+                # Leave $u as-is on the (very unlikely) decode failure.
               }
             }
             $u = $u -replace '\\','/'

--- a/.github/workflows/code-inspection.yml
+++ b/.github/workflows/code-inspection.yml
@@ -102,16 +102,31 @@ jobs:
 
       - name: Run InspectCode
         if: steps.changed.outputs.count != '0'
+        # PR-controlled file names flow into the include mask. Pass the mask
+        # and solution via env vars (which run scripts see as plain shell
+        # variables) instead of interpolating the GitHub expression directly
+        # into the script body — a file name containing quotes or command
+        # substitution could otherwise break out of the quoted argument and
+        # execute arbitrary commands on the runner.
+        env:
+          INCLUDE_MASK: ${{ steps.changed.outputs.mask }}
+          SOLUTION: ${{ env.SOLUTION }}
         run: |
-          dotnet jb inspectcode "${{ env.SOLUTION }}" \
+          dotnet jb inspectcode "$SOLUTION" \
             --output=inspectcode.sarif \
-            --include="${{ steps.changed.outputs.mask }}" \
+            --include="$INCLUDE_MASK" \
             --no-build \
             --verbosity=WARN
 
       - name: Report issues
         if: steps.changed.outputs.count != '0'
         shell: pwsh
+        # Same defense as Run InspectCode: never interpolate PR-controlled
+        # values directly into the run script. The pwsh body reads them via
+        # $env: so any quoting/escaping is the shell's problem, not ours.
+        env:
+          INCLUDE_MASK: ${{ steps.changed.outputs.mask }}
+          SOLUTION: ${{ env.SOLUTION }}
         run: |
           # Defend against the prior step exiting 0 without producing a SARIF
           # report (e.g. include mask matched nothing, jb writing was aborted
@@ -121,14 +136,14 @@ jobs:
           if (-not (Test-Path inspectcode.sarif)) {
               Write-Host "::error::InspectCode produced no SARIF report at inspectcode.sarif."
               Write-Host "::error::Rerun locally to investigate:"
-              Write-Host "::error::  dotnet jb inspectcode '${{ env.SOLUTION }}' --output=inspectcode.sarif --include='${{ steps.changed.outputs.mask }}' --no-build --verbosity=WARN"
+              Write-Host "::error::  dotnet jb inspectcode `"$($env:SOLUTION)`" --output=inspectcode.sarif --include=`"$($env:INCLUDE_MASK)`" --no-build --verbosity=WARN"
               exit 1
           }
           $sarifInfo = Get-Item inspectcode.sarif
           if ($sarifInfo.Length -eq 0) {
               Write-Host "::error::InspectCode produced an empty SARIF report at inspectcode.sarif (0 bytes)."
               Write-Host "::error::Rerun locally to investigate:"
-              Write-Host "::error::  dotnet jb inspectcode '${{ env.SOLUTION }}' --output=inspectcode.sarif --include='${{ steps.changed.outputs.mask }}' --no-build --verbosity=WARN"
+              Write-Host "::error::  dotnet jb inspectcode `"$($env:SOLUTION)`" --output=inspectcode.sarif --include=`"$($env:INCLUDE_MASK)`" --no-build --verbosity=WARN"
               exit 1
           }
 
@@ -155,7 +170,7 @@ jobs:
           } catch {
               Write-Host "::error::Failed to parse inspectcode.sarif as JSON: $($_.Exception.Message)"
               Write-Host "::error::Rerun locally to investigate:"
-              Write-Host "::error::  dotnet jb inspectcode '${{ env.SOLUTION }}' --output=inspectcode.sarif --include='${{ steps.changed.outputs.mask }}' --no-build --verbosity=WARN"
+              Write-Host "::error::  dotnet jb inspectcode `"$($env:SOLUTION)`" --output=inspectcode.sarif --include=`"$($env:INCLUDE_MASK)`" --no-build --verbosity=WARN"
               exit 1
           }
 

--- a/.github/workflows/code-inspection.yml
+++ b/.github/workflows/code-inspection.yml
@@ -240,7 +240,7 @@ jobs:
           }
 
           $failures = @($sarif.runs[0].results | Where-Object {
-              $_.level -eq 'warning' -and
+              $_.level -in @('warning', 'error') -and
               $_.ruleId -notin $ignored -and
               $stagedSet.Contains((Normalize-SarifUri $_.locations[0].physicalLocation.artifactLocation.uri))
           })

--- a/.github/workflows/code-inspection.yml
+++ b/.github/workflows/code-inspection.yml
@@ -101,10 +101,20 @@ jobs:
           function Normalize-SarifUri {
             param([Parameter(Mandatory)][string]$Uri)
             $u = $Uri
-            if ($u -match '^file:/{2,3}') { $u = $u -replace '^file:/{2,3}', '/' }
+            # file:// URIs need [System.Uri] parsing to handle Windows-form
+            # `file:///C:/...` correctly (a naive scheme strip would leave
+            # `/C:/...` which never matches the workspace root).
+            if ($u -match '^file:') {
+              try {
+                $u = ([System.Uri]$u).LocalPath
+              } catch {
+                $u = $u -replace '^file:/{2,3}', ''
+              }
+            }
             $u = $u -replace '\\','/'
             if ($u -like './*') { $u = $u.Substring(2) }
-            if ($u -like "$workspacePosix/*") { $u = $u.Substring($workspacePosix.Length + 1) }
+            $cmp = if ($IsWindows) { [StringComparison]::OrdinalIgnoreCase } else { [StringComparison]::Ordinal }
+            if ($u.StartsWith("$workspacePosix/", $cmp)) { $u = $u.Substring($workspacePosix.Length + 1) }
             return $u.TrimStart('/')
           }
 

--- a/.github/workflows/code-inspection.yml
+++ b/.github/workflows/code-inspection.yml
@@ -152,8 +152,13 @@ jobs:
           INCLUDE_MASK: ${{ steps.changed.outputs.mask }}
           SOLUTION: ${{ env.SOLUTION }}
         run: |
+          # InspectCode defaults to XML regardless of output filename — the
+          # .sarif extension does NOT auto-select format. Without
+          # --format=Sarif the downstream ConvertFrom-Json parse blows up
+          # on XML output.
           dotnet jb inspectcode "$SOLUTION" \
             --output=inspectcode.sarif \
+            --format=Sarif \
             --include="$INCLUDE_MASK" \
             --no-build \
             --verbosity=WARN
@@ -176,14 +181,14 @@ jobs:
           if (-not (Test-Path inspectcode.sarif)) {
               Write-Host "::error::InspectCode produced no SARIF report at inspectcode.sarif."
               Write-Host "::error::Rerun locally to investigate:"
-              Write-Host "::error::  dotnet jb inspectcode `"$($env:SOLUTION)`" --output=inspectcode.sarif --include=`"$($env:INCLUDE_MASK)`" --no-build --verbosity=WARN"
+              Write-Host "::error::  dotnet jb inspectcode `"$($env:SOLUTION)`" --output=inspectcode.sarif --format=Sarif --include=`"$($env:INCLUDE_MASK)`" --no-build --verbosity=WARN"
               exit 1
           }
           $sarifInfo = Get-Item inspectcode.sarif
           if ($sarifInfo.Length -eq 0) {
               Write-Host "::error::InspectCode produced an empty SARIF report at inspectcode.sarif (0 bytes)."
               Write-Host "::error::Rerun locally to investigate:"
-              Write-Host "::error::  dotnet jb inspectcode `"$($env:SOLUTION)`" --output=inspectcode.sarif --include=`"$($env:INCLUDE_MASK)`" --no-build --verbosity=WARN"
+              Write-Host "::error::  dotnet jb inspectcode `"$($env:SOLUTION)`" --output=inspectcode.sarif --format=Sarif --include=`"$($env:INCLUDE_MASK)`" --no-build --verbosity=WARN"
               exit 1
           }
 
@@ -210,7 +215,7 @@ jobs:
           } catch {
               Write-Host "::error::Failed to parse inspectcode.sarif as JSON: $($_.Exception.Message)"
               Write-Host "::error::Rerun locally to investigate:"
-              Write-Host "::error::  dotnet jb inspectcode `"$($env:SOLUTION)`" --output=inspectcode.sarif --include=`"$($env:INCLUDE_MASK)`" --no-build --verbosity=WARN"
+              Write-Host "::error::  dotnet jb inspectcode `"$($env:SOLUTION)`" --output=inspectcode.sarif --format=Sarif --include=`"$($env:INCLUDE_MASK)`" --no-build --verbosity=WARN"
               exit 1
           }
 

--- a/.github/workflows/code-inspection.yml
+++ b/.github/workflows/code-inspection.yml
@@ -66,15 +66,20 @@ jobs:
           # metacharacters survive intact (basenames in particular).
           mapfile -d '' files < <(git diff --name-only --diff-filter=ACMR -z "$base...$head" |
                                   awk -v RS='\0' -v ORS='\0' '/\.cs$/')
-          # Reject CR/LF or ';' in any changed filename before we write to
-          # GITHUB_OUTPUT. Git permits newlines and semicolons in paths.
-          # CR/LF would let a crafted filename inject extra output records
-          # (e.g. override `count` or `mask`) and bypass the gate. ';' is
-          # the InspectCode --include separator, so a basename containing
-          # ';' would silently split into multiple bogus masks and the real
-          # file would never be inspected — a quiet bypass of CI. Fail
-          # closed instead of trying to be clever — nobody legitimately
-          # checks in a .cs file whose name contains a newline or ';'.
+          # Reject CR/LF or InspectCode --include metacharacters in any
+          # changed filename before we write to GITHUB_OUTPUT. Git permits
+          # newlines, ';', '*', '?', '[' and ']' in paths. CR/LF would let a
+          # crafted filename inject extra output records (e.g. override
+          # `count` or `mask`) and bypass the gate. ';' is the InspectCode
+          # --include separator, so a basename containing ';' would silently
+          # split into multiple bogus masks and the real file would never be
+          # inspected. '*', '?', '[' and ']' are InspectCode wildcard
+          # metacharacters: a basename containing them would be interpreted
+          # as a pattern rather than a literal, so InspectCode could end up
+          # inspecting a *different* file that matches the pattern and skip
+          # the staged one — also a quiet bypass of CI. Fail closed instead
+          # of trying to be clever — nobody legitimately checks in a .cs
+          # file whose name contains any of these.
           for f in "${files[@]}"; do
             case "$f" in
               *$'\n'*|*$'\r'*)
@@ -84,9 +89,15 @@ jobs:
                 ;;
             esac
             case "$(basename -- "$f")" in
-              *';'*)
-                echo "::error::Refusing to inspect: changed filename basename contains ';' (the InspectCode --include separator): $f" >&2
-                exit 1
+              *$'\n'*|*$'\r'*) ;;  # already caught above
+              *)
+                # Bash case `[...]` bracket expressions can't cleanly cover
+                # `]`, `[`, `;`, `*`, `?` without quoting gymnastics that
+                # break on different shell versions; use grep for clarity.
+                if printf '%s' "$(basename -- "$f")" | LC_ALL=C grep -q '[][;*?]'; then
+                  echo "::error::Refusing to inspect: changed filename basename contains an InspectCode --include metacharacter (one of ;, *, ?, [, ]): $f" >&2
+                  exit 1
+                fi
                 ;;
             esac
           done

--- a/.github/workflows/code-inspection.yml
+++ b/.github/workflows/code-inspection.yml
@@ -52,11 +52,16 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          # Three-dot range (base...head) limits the diff to files actually
+          # changed on the PR branch relative to the merge-base, ignoring
+          # files that only moved on the base branch since the PR diverged.
+          # A two-dot range would surface unrelated base-branch churn and
+          # could fail the gate on files this PR never touched.
           base="${{ github.event.pull_request.base.sha }}"
           head="${{ github.event.pull_request.head.sha }}"
           # NUL-delimit so paths containing whitespace, quotes, or other shell
           # metacharacters survive intact (basenames in particular).
-          mapfile -d '' files < <(git diff --name-only --diff-filter=ACMR -z "$base" "$head" |
+          mapfile -d '' files < <(git diff --name-only --diff-filter=ACMR -z "$base...$head" |
                                   awk -v RS='\0' -v ORS='\0' '/\.cs$/')
           if [ "${#files[@]}" -eq 0 ]; then
             echo "No .cs files changed — skipping inspection."

--- a/.github/workflows/code-inspection.yml
+++ b/.github/workflows/code-inspection.yml
@@ -1,0 +1,113 @@
+name: Code Inspection
+
+on:
+  pull_request:
+    branches:
+      - master
+      - develop
+    paths:
+      - 'src/**/*.cs'
+      - 'src/JamesConsulting.sln'
+      - 'src/Directory.Build.props'
+      - 'src/Directory.Build.targets'
+      - '.editorconfig'
+      - '.github/workflows/code-inspection.yml'
+      - 'scripts/precommit-inspect.ps1'
+
+permissions:
+  contents: read
+  pull-requests: read
+
+env:
+  SOLUTION: 'src/JamesConsulting.sln'
+  # No rules currently excluded. Add rule IDs (comma-separated) here if a regression window requires it.
+  IGNORED_RULES: ''
+
+jobs:
+  inspect:
+    name: JetBrains InspectCode
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            9.0.x
+            10.0.x
+
+      - name: Restore solution
+        run: dotnet restore ${{ env.SOLUTION }}
+
+      - name: Install JetBrains InspectCode
+        run: dotnet tool install -g JetBrains.ReSharper.GlobalTools
+
+      - name: Determine changed .cs files
+        id: changed
+        shell: bash
+        run: |
+          set -e
+          base="${{ github.event.pull_request.base.sha }}"
+          head="${{ github.event.pull_request.head.sha }}"
+          files=$(git diff --name-only --diff-filter=ACMR "$base" "$head" | grep -E '\.cs$' || true)
+          if [ -z "$files" ]; then
+            echo "No .cs files changed — skipping inspection."
+            echo "count=0" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          count=$(printf '%s\n' "$files" | wc -l | tr -d ' ')
+          echo "count=$count" >> "$GITHUB_OUTPUT"
+          mask=$(printf '%s\n' "$files" | xargs -n1 basename | sort -u | sed 's#^#**/#' | paste -sd ';' -)
+          echo "mask=$mask" >> "$GITHUB_OUTPUT"
+          printf '%s\n' "$files" > .changed-files.txt
+
+      - name: Run InspectCode
+        if: steps.changed.outputs.count != '0'
+        run: |
+          jb inspectcode "${{ env.SOLUTION }}" \
+            --output=inspectcode.sarif \
+            --include="${{ steps.changed.outputs.mask }}" \
+            --no-build \
+            --verbosity=WARN
+
+      - name: Report issues
+        if: steps.changed.outputs.count != '0'
+        shell: pwsh
+        run: |
+          $ignored = '${{ env.IGNORED_RULES }}' -split ','
+          $staged = @(Get-Content .changed-files.txt) | ForEach-Object { $_ -replace '\\','/' }
+          $stagedSet = [System.Collections.Generic.HashSet[string]]::new([StringComparer]::OrdinalIgnoreCase)
+          $staged | ForEach-Object { [void]$stagedSet.Add($_) }
+
+          $sarif = Get-Content inspectcode.sarif -Raw | ConvertFrom-Json
+          $failures = @($sarif.runs[0].results | Where-Object {
+              $_.level -eq 'warning' -and
+              $_.ruleId -notin $ignored -and
+              $stagedSet.Contains(($_.locations[0].physicalLocation.artifactLocation.uri -replace '\\','/'))
+          })
+
+          if ($failures.Count -eq 0) {
+            Write-Host "::notice::No blocking inspection issues in changed files."
+            exit 0
+          }
+
+          Write-Host "::error::$($failures.Count) blocking inspection issue(s) in changed files:"
+          foreach ($f in $failures) {
+            $loc = $f.locations[0].physicalLocation
+            $file = $loc.artifactLocation.uri
+            $line = $loc.region.startLine
+            Write-Host ("::error file={0},line={1},title={2}::{3}" -f $file, $line, $f.ruleId, $f.message.text)
+          }
+          exit 1
+
+      - name: Upload SARIF report
+        if: always() && steps.changed.outputs.count != '0'
+        uses: actions/upload-artifact@v4
+        with:
+          name: inspectcode-sarif
+          path: inspectcode.sarif
+          if-no-files-found: ignore

--- a/scripts/precommit-inspect.ps1
+++ b/scripts/precommit-inspect.ps1
@@ -127,6 +127,20 @@ if ($null -eq $jb) {
         exit 0
     }
 
+    # If a manifest exists, the pinned tool is the source of truth. Falling
+    # back to a global install would silently swap the developer onto a
+    # different (likely newer) InspectCode build than CI, defeating the
+    # whole point of pinning. Fail-soft (skip) and surface the restore
+    # error so the developer can fix it deliberately.
+    $manifest = Join-Path $repoRoot '.config/dotnet-tools.json'
+    if (Test-Path $manifest) {
+        Write-Warning "pre-commit: tool manifest exists at .config/dotnet-tools.json but 'dotnet tool restore' failed."
+        Write-Warning "  Not falling back to a global install — that would diverge from the pinned version used by CI."
+        Write-Warning "  Run manually to diagnose: dotnet tool restore"
+        Write-Warning "  Bypass in an emergency with: git commit --no-verify"
+        exit 0
+    }
+
     # No manifest + dotnet present — last-resort one-time global install.
     # The manifest path above is the preferred path; this branch only fires
     # in repos that haven't (yet) added .config/dotnet-tools.json.

--- a/scripts/precommit-inspect.ps1
+++ b/scripts/precommit-inspect.ps1
@@ -25,7 +25,12 @@ param(
 
 $ErrorActionPreference = 'Stop'
 
-$repoRoot = (& git rev-parse --show-toplevel).Trim()
+$repoRootRaw = & git rev-parse --show-toplevel 2>$null
+if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($repoRootRaw)) {
+    Write-Warning "pre-commit: not inside a git repo; skipping inspection."
+    exit 0
+}
+$repoRoot = $repoRootRaw.Trim()
 Set-Location $repoRoot
 
 if (-not $Solution) {
@@ -119,12 +124,24 @@ $jbArgs = @(
 
 $sw = [Diagnostics.Stopwatch]::StartNew()
 & jb inspectcode @jbArgs | Out-Null
+$jbExit = $LASTEXITCODE
 $sw.Stop()
 Write-Host "pre-commit: inspection finished in $([int]$sw.Elapsed.TotalSeconds)s." -ForegroundColor DarkGray
 
+if ($jbExit -ne 0) {
+    Write-Host "" -ForegroundColor Red
+    Write-Host "pre-commit: 'jb inspectcode' exited with code $jbExit (restore/build/tool failure)." -ForegroundColor Red
+    Write-Host "  Re-run manually to see the full output:" -ForegroundColor Yellow
+    Write-Host "    jb inspectcode $($jbArgs -join ' ')" -ForegroundColor Yellow
+    Write-Host "  Bypass with: git commit --no-verify" -ForegroundColor Yellow
+    exit 1
+}
+
 if (-not (Test-Path $reportPath)) {
-    Write-Warning "pre-commit: InspectCode did not produce a report; allowing commit."
-    exit 0
+    Write-Host "pre-commit: 'jb inspectcode' returned 0 but produced no report at $reportPath." -ForegroundColor Red
+    Write-Host "  This usually means the include mask matched no files in the solution." -ForegroundColor Yellow
+    Write-Host "  Bypass with: git commit --no-verify" -ForegroundColor Yellow
+    exit 1
 }
 
 $stagedSet = [System.Collections.Generic.HashSet[string]]::new([StringComparer]::OrdinalIgnoreCase)

--- a/scripts/precommit-inspect.ps1
+++ b/scripts/precommit-inspect.ps1
@@ -333,7 +333,7 @@ $ignoredRulesNormalized = @(
 )
 
 $results = @($sarif.runs[0].results | Where-Object {
-        $_.level -eq 'warning' -and
+        $_.level -in @('warning', 'error') -and
         $_.ruleId -notin $ignoredRulesNormalized
     })
 

--- a/scripts/precommit-inspect.ps1
+++ b/scripts/precommit-inspect.ps1
@@ -207,16 +207,19 @@ function Restore-WorkingTree {
 $script:stashed = $stashed
 
 # --include uses file-name wildcards; we use **/<leaf> so patterns match the
-# solution layout. The mask is semicolon-delimited, so a basename containing
-# `;` would silently split into multiple bogus masks and the real file would
-# never be inspected — a quiet bypass of the pre-commit gate. Git permits
-# `;` in path names; fail closed (don't try to be clever) when a staged
-# basename contains a separator we can't escape.
-$badSep = @($stagedFiles | Where-Object { (Split-Path $_ -Leaf) -match ';' })
+# solution layout. The mask is semicolon-delimited and InspectCode interprets
+# `*`, `?`, `[`, `]` as wildcard metacharacters. A basename containing any of
+# these would either split into bogus masks (`;`) or be interpreted as a
+# pattern rather than a literal — so InspectCode could end up inspecting a
+# *different* file that happens to match the pattern and skip the staged one,
+# letting warnings through. Git permits all of these characters in path
+# names; fail closed (don't try to be clever) when a staged basename
+# contains one we can't escape.
+$badSep = @($stagedFiles | Where-Object { (Split-Path $_ -Leaf) -match '[;*?\[\]]' })
 if ($badSep.Count -gt 0) {
     Restore-WorkingTree
     Write-Host ""
-    Write-Host "pre-commit: refusing to inspect — staged filename contains ';' which is the InspectCode --include separator:" -ForegroundColor Red
+    Write-Host "pre-commit: refusing to inspect — staged filename contains InspectCode --include metacharacters (;, *, ?, [, ]):" -ForegroundColor Red
     $badSep | ForEach-Object { Write-Host "  $_" -ForegroundColor Red }
     Write-Host ""
     Write-Host "  Rename the file (or commit it under a different name) and re-stage." -ForegroundColor Yellow

--- a/scripts/precommit-inspect.ps1
+++ b/scripts/precommit-inspect.ps1
@@ -71,13 +71,32 @@ if (-not $Solution) {
 # explicitly before further processing — the rest of the script (include
 # mask, staged-set membership, error messages) cannot represent CR/LF
 # safely, so fail closed in that case.
-$gitOutput = & git diff --cached -z --name-only --diff-filter=ACMR
-if ($LASTEXITCODE -ne 0) {
-    Write-Host "pre-commit: 'git diff --cached' failed (exit $LASTEXITCODE); skipping inspection." -ForegroundColor Red
-    exit 1
+#
+# We MUST capture git's stdout as raw bytes, not via `&` invocation:
+# PowerShell's native-command capture is line-oriented and splits on
+# newlines before we can split on NUL, so a `\n` inside a single staged
+# path would corrupt the array (one logical path becomes two array
+# entries) and the CR/LF check below would not see it. Redirect to a
+# temp file via `Start-Process`, then read the file as bytes — that
+# preserves NUL terminators and embedded newlines verbatim.
+$diffTempFile = Join-Path ([IO.Path]::GetTempPath()) "precommit-inspect-diff-$([Guid]::NewGuid()).bin"
+try {
+    $proc = Start-Process -FilePath 'git' `
+        -ArgumentList @('diff','--cached','-z','--name-only','--diff-filter=ACMR') `
+        -NoNewWindow -Wait -PassThru `
+        -RedirectStandardOutput $diffTempFile
+    if ($proc.ExitCode -ne 0) {
+        Write-Host "pre-commit: 'git diff --cached -z' failed (exit $($proc.ExitCode)); skipping inspection." -ForegroundColor Red
+        exit 1
+    }
+    $bytes = if (Test-Path $diffTempFile) { [System.IO.File]::ReadAllBytes($diffTempFile) } else { [byte[]]@() }
+} finally {
+    if (Test-Path $diffTempFile) { Remove-Item $diffTempFile -Force -ErrorAction SilentlyContinue }
 }
-# A NUL-terminated list ends with an empty element after split; drop it.
-$stagedRaw = if ($gitOutput) { $gitOutput -split "`0" | Where-Object { $_ -ne '' } } else { @() }
+$diffText = if ($bytes.Length -gt 0) { [System.Text.Encoding]::UTF8.GetString($bytes) } else { '' }
+# `-z` is terminator-style (trailing NUL after every record), so the last
+# split element is the empty string; drop empties.
+$stagedRaw = if ($diffText) { $diffText -split "`0" | Where-Object { $_ -ne '' } } else { @() }
 $stagedFiles = @($stagedRaw | Where-Object { $_ -like '*.cs' })
 
 $badNewline = @($stagedFiles | Where-Object { $_ -match "[`r`n]" })

--- a/scripts/precommit-inspect.ps1
+++ b/scripts/precommit-inspect.ps1
@@ -130,14 +130,20 @@ function Ensure-Jb {
     # .config/dotnet-tools.json. Returns a hashtable describing how to invoke
     # the tool: @{ Command = 'dotnet'|'jb'; Prefix = @('jb') | @() }.
     #
-    # When a manifest is present but `dotnet tool restore` fails, we MUST
-    # return $null instead of falling through to a globally-installed `jb`.
-    # Otherwise the gate would silently run a different (likely newer)
+    # When a manifest is present the manifest pin is authoritative. If
+    # `dotnet` is missing or `dotnet tool restore` fails, we MUST return
+    # $null instead of falling through to a globally-installed `jb` —
+    # otherwise the gate would silently run a different (likely newer)
     # InspectCode build than CI, defeating the pin. The fail-soft branch
-    # below (which fires on $null return) surfaces the restore error so
-    # the developer can fix it deliberately.
+    # below (which fires on $null return) surfaces the error so the
+    # developer can fix it deliberately.
     $manifest = Join-Path $repoRoot '.config/dotnet-tools.json'
-    if ((Test-Path $manifest) -and (Get-Command dotnet -ErrorAction SilentlyContinue)) {
+    if (Test-Path $manifest) {
+        if (-not (Get-Command dotnet -ErrorAction SilentlyContinue)) {
+            Write-Warning "pre-commit: '.config/dotnet-tools.json' exists but 'dotnet' is not on PATH; not falling back to global jb (manifest pin takes precedence)."
+            Write-Warning "  Install the .NET SDK from https://aka.ms/dotnet/download and retry."
+            return $null
+        }
         if (-not $script:JbRestored) {
             & dotnet tool restore 2>&1 | Out-Null
             if ($LASTEXITCODE -ne 0) {

--- a/scripts/precommit-inspect.ps1
+++ b/scripts/precommit-inspect.ps1
@@ -245,6 +245,10 @@ $jbArgs = @(
     'inspectcode',
     $Solution,
     "--output=$reportPath",
+    # InspectCode defaults to XML regardless of output filename — the .sarif
+    # extension does NOT auto-select format. Without --format=Sarif the
+    # downstream ConvertFrom-Json parse blows up on XML output.
+    '--format=Sarif',
     "--include=$includeMask",
     '--no-build',
     '--verbosity=WARN'

--- a/scripts/precommit-inspect.ps1
+++ b/scripts/precommit-inspect.ps1
@@ -150,15 +150,47 @@ $stagedFiles | ForEach-Object { [void]$stagedSet.Add(($_ -replace '\\', '/')) }
 $sarif = Get-Content $reportPath -Raw | ConvertFrom-Json
 Remove-Item $reportPath -Force -ErrorAction SilentlyContinue
 
+# Normalize IgnoredRules: trim, drop empties, and split on commas in case a
+# single comma-separated string was passed (e.g., `-IgnoredRules "IDE0005, CA1822"`).
+# Without this, callers passing a CSV value would never match because the leading
+# space (or the bare comma) would prevent equality with SARIF rule IDs.
+$ignoredRulesNormalized = @(
+    $IgnoredRules |
+        Where-Object { $_ -ne $null } |
+        ForEach-Object { $_ -split ',' } |
+        ForEach-Object { $_.Trim() } |
+        Where-Object   { $_ -ne '' }
+)
+
 $results = @($sarif.runs[0].results | Where-Object {
         $_.level -eq 'warning' -and
-        $_.ruleId -notin $IgnoredRules
+        $_.ruleId -notin $ignoredRulesNormalized
     })
+
+# SARIF artifactLocation.uri can be:
+#   - repo-relative POSIX path (the common case from `jb inspectcode`)
+#   - absolute path (Windows or POSIX)
+#   - file:// or file:/// URI
+#   - './'-prefixed repo-relative path
+# Normalize all of these to repo-relative POSIX before set membership, otherwise
+# real violations in staged files would silently fall through and the gate would
+# pass commits it should block.
+$repoRootPosix = ($repoRoot -replace '\\', '/').TrimEnd('/')
+function Normalize-SarifUri {
+    param([Parameter(Mandatory)][string]$Uri)
+    $u = $Uri
+    if ($u -match '^file:/{2,3}') { $u = $u -replace '^file:/{2,3}', '/' }
+    $u = $u -replace '\\', '/'
+    if ($u -like './*') { $u = $u.Substring(2) }
+    # Absolute path inside the repo root → strip prefix.
+    if ($u -like "$repoRootPosix/*") { $u = $u.Substring($repoRootPosix.Length + 1) }
+    return $u.TrimStart('/')
+}
 
 # Only fail for issues in files that were actually staged (filename-wildcard
 # include may match same-named files in other folders).
 $failures = @($results | Where-Object {
-        $uri = $_.locations[0].physicalLocation.artifactLocation.uri -replace '\\', '/'
+        $uri = Normalize-SarifUri $_.locations[0].physicalLocation.artifactLocation.uri
         $stagedSet.Contains($uri)
     })
 

--- a/scripts/precommit-inspect.ps1
+++ b/scripts/precommit-inspect.ps1
@@ -206,7 +206,23 @@ function Restore-WorkingTree {
 }
 $script:stashed = $stashed
 
-# --include uses file-name wildcards; we use **/<leaf> so patterns match the solution layout.
+# --include uses file-name wildcards; we use **/<leaf> so patterns match the
+# solution layout. The mask is semicolon-delimited, so a basename containing
+# `;` would silently split into multiple bogus masks and the real file would
+# never be inspected — a quiet bypass of the pre-commit gate. Git permits
+# `;` in path names; fail closed (don't try to be clever) when a staged
+# basename contains a separator we can't escape.
+$badSep = @($stagedFiles | Where-Object { (Split-Path $_ -Leaf) -match ';' })
+if ($badSep.Count -gt 0) {
+    Restore-WorkingTree
+    Write-Host ""
+    Write-Host "pre-commit: refusing to inspect — staged filename contains ';' which is the InspectCode --include separator:" -ForegroundColor Red
+    $badSep | ForEach-Object { Write-Host "  $_" -ForegroundColor Red }
+    Write-Host ""
+    Write-Host "  Rename the file (or commit it under a different name) and re-stage." -ForegroundColor Yellow
+    Write-Host "  Bypass in an emergency with: git commit --no-verify" -ForegroundColor Yellow
+    exit 1
+}
 $includeMask = ($stagedFiles | ForEach-Object { "**/" + (Split-Path $_ -Leaf) } | Sort-Object -Unique) -join ';'
 
 $jbArgs = @(

--- a/scripts/precommit-inspect.ps1
+++ b/scripts/precommit-inspect.ps1
@@ -404,12 +404,26 @@ function Normalize-SarifUri {
     # file:// URIs need [System.Uri] parsing to handle Windows-form
     # `file:///C:/repo/...` correctly. A naive `^file:/{2,3}` -> '/'
     # replace would yield '/C:/repo/...' which would never match
-    # $repoRootPosix on Windows.
+    # $repoRootPosix on Windows. [System.Uri].LocalPath also handles
+    # percent-decoding for us.
     if ($u -match '^file:') {
         try {
             $u = ([System.Uri]$u).LocalPath
         } catch {
             $u = $u -replace '^file:/{2,3}', ''
+            $u = [System.Uri]::UnescapeDataString($u)
+        }
+    } else {
+        # Non-file SARIF URIs are still URIs — relative paths containing
+        # spaces or other URI-reserved characters are percent-encoded
+        # (e.g. `src/My%20File.cs`). The staged set stores raw git paths,
+        # so without decoding here those findings would never match and
+        # the gate would let blocking warnings through.
+        try {
+            $u = [System.Uri]::UnescapeDataString($u)
+        } catch {
+            # Leave $u as-is on the (very unlikely) decode failure;
+            # downstream membership check just won't match.
         }
     }
     $u = $u -replace '\\', '/'

--- a/scripts/precommit-inspect.ps1
+++ b/scripts/precommit-inspect.ps1
@@ -29,10 +29,17 @@ $repoRoot = (& git rev-parse --show-toplevel).Trim()
 Set-Location $repoRoot
 
 if (-not $Solution) {
-    # Auto-detect: prefer src/*.sln (single hit), fall back to root *.sln.
-    $candidates = @(Get-ChildItem -Path 'src' -Filter '*.sln' -File -ErrorAction SilentlyContinue) +
-                  @(Get-ChildItem -Path '.'    -Filter '*.sln' -File -ErrorAction SilentlyContinue)
-    $candidates = @($candidates | Sort-Object FullName -Unique)
+    # Auto-detect: prefer src/*.sln (the canonical layout in this org); only
+    # fall back to a root-level *.sln when src/ has none. Using a flat
+    # sort+first across both folders would let a stray root .sln win even
+    # when src/*.sln exists, which is the opposite of what we want.
+    $srcCandidates  = @(Get-ChildItem -Path 'src' -Filter '*.sln' -File -ErrorAction SilentlyContinue)
+    $rootCandidates = @(Get-ChildItem -Path '.'   -Filter '*.sln' -File -ErrorAction SilentlyContinue)
+    if ($srcCandidates.Count -gt 0) {
+        $candidates = @($srcCandidates | Sort-Object FullName)
+    } else {
+        $candidates = @($rootCandidates | Sort-Object FullName)
+    }
     if ($candidates.Count -eq 0) {
         Write-Warning "pre-commit: no .sln found under src/ or repo root; skipping inspection."
         exit 0

--- a/scripts/precommit-inspect.ps1
+++ b/scripts/precommit-inspect.ps1
@@ -1,0 +1,159 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Pre-commit quality gate: runs JetBrains InspectCode on staged .cs files.
+
+.DESCRIPTION
+    Fails the commit when any warning-level Rider/Roslyn inspection fires in
+    a staged file. Note-level suggestions are ignored.
+
+    First run: if `jb` is missing and `dotnet` is on PATH, this script will
+    install JetBrains.ReSharper.GlobalTools as a global tool automatically.
+    Pass `-SkipAutoInstall` to disable that behavior.
+
+    Bypass in an emergency with: git commit --no-verify
+
+    One-time setup per machine (after cloning a repo that ships this script):
+        pwsh scripts/setup-hooks.ps1
+#>
+[CmdletBinding()]
+param(
+    [string]   $Solution,
+    [string[]] $IgnoredRules    = @(),
+    [switch]   $SkipAutoInstall
+)
+
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = (& git rev-parse --show-toplevel).Trim()
+Set-Location $repoRoot
+
+if (-not $Solution) {
+    # Auto-detect: prefer src/*.sln (single hit), fall back to root *.sln.
+    $candidates = @(Get-ChildItem -Path 'src' -Filter '*.sln' -File -ErrorAction SilentlyContinue) +
+                  @(Get-ChildItem -Path '.'    -Filter '*.sln' -File -ErrorAction SilentlyContinue)
+    $candidates = @($candidates | Sort-Object FullName -Unique)
+    if ($candidates.Count -eq 0) {
+        Write-Warning "pre-commit: no .sln found under src/ or repo root; skipping inspection."
+        exit 0
+    }
+    if ($candidates.Count -gt 1) {
+        Write-Warning "pre-commit: multiple .sln files found, using $($candidates[0].FullName)."
+        Write-Warning "  Pass -Solution <path> explicitly to override."
+    }
+    $Solution = (Resolve-Path $candidates[0].FullName -Relative)
+}
+
+$stagedFiles = & git diff --cached --name-only --diff-filter=ACMR | Where-Object { $_ -like '*.cs' }
+
+if (-not $stagedFiles) {
+    Write-Host "pre-commit: no staged .cs files - skipping inspection." -ForegroundColor DarkGray
+    exit 0
+}
+
+function Ensure-JbOnPath {
+    if (Get-Command jb -ErrorAction SilentlyContinue) { return $true }
+
+    # JetBrains.ReSharper.GlobalTools installs to the dotnet tools directory,
+    # which is on PATH by default on most setups but not always in a fresh
+    # shell. Probe the canonical location and prepend it for this run.
+    $toolsDir = if ($IsWindows) {
+        Join-Path $env:USERPROFILE '.dotnet\tools'
+    } else {
+        Join-Path $HOME '.dotnet/tools'
+    }
+    if (Test-Path (Join-Path $toolsDir (if ($IsWindows) { 'jb.exe' } else { 'jb' }))) {
+        $env:PATH = "$toolsDir$([IO.Path]::PathSeparator)$env:PATH"
+        if (Get-Command jb -ErrorAction SilentlyContinue) { return $true }
+    }
+    return $false
+}
+
+if (-not (Ensure-JbOnPath)) {
+    if ($SkipAutoInstall) {
+        Write-Warning "pre-commit: 'jb' not on PATH and -SkipAutoInstall set; skipping inspection."
+        exit 0
+    }
+    if (-not (Get-Command dotnet -ErrorAction SilentlyContinue)) {
+        Write-Warning "pre-commit: neither 'jb' nor 'dotnet' on PATH; skipping inspection."
+        Write-Warning "Install .NET SDK + 'dotnet tool install -g JetBrains.ReSharper.GlobalTools' to enable."
+        exit 0
+    }
+
+    Write-Host "pre-commit: 'jb' not found, installing JetBrains.ReSharper.GlobalTools (one-time)..." -ForegroundColor Yellow
+    & dotnet tool install -g JetBrains.ReSharper.GlobalTools 2>&1 | Out-Host
+    if ($LASTEXITCODE -ne 0) {
+        Write-Warning "pre-commit: auto-install failed; skipping inspection."
+        Write-Warning "Run manually: dotnet tool install -g JetBrains.ReSharper.GlobalTools"
+        exit 0
+    }
+    if (-not (Ensure-JbOnPath)) {
+        Write-Warning "pre-commit: 'jb' still not on PATH after install; skipping inspection."
+        Write-Warning "Add `$HOME/.dotnet/tools (or %USERPROFILE%\.dotnet\tools) to PATH and retry."
+        exit 0
+    }
+    Write-Host "pre-commit: jb installed." -ForegroundColor Green
+}
+
+Write-Host "pre-commit: inspecting $($stagedFiles.Count) staged .cs file(s)..." -ForegroundColor Cyan
+
+$reportPath = Join-Path ([IO.Path]::GetTempPath()) "precommit-inspect-$([Guid]::NewGuid()).sarif"
+
+# --include uses file-name wildcards; we use **/<leaf> so patterns match the solution layout.
+$includeMask = ($stagedFiles | ForEach-Object { "**/" + (Split-Path $_ -Leaf) } | Sort-Object -Unique) -join ';'
+
+$jbArgs = @(
+    $Solution,
+    "--output=$reportPath",
+    "--include=$includeMask",
+    '--no-build',
+    '--verbosity=WARN'
+)
+
+$sw = [Diagnostics.Stopwatch]::StartNew()
+& jb inspectcode @jbArgs | Out-Null
+$sw.Stop()
+Write-Host "pre-commit: inspection finished in $([int]$sw.Elapsed.TotalSeconds)s." -ForegroundColor DarkGray
+
+if (-not (Test-Path $reportPath)) {
+    Write-Warning "pre-commit: InspectCode did not produce a report; allowing commit."
+    exit 0
+}
+
+$stagedSet = [System.Collections.Generic.HashSet[string]]::new([StringComparer]::OrdinalIgnoreCase)
+$stagedFiles | ForEach-Object { [void]$stagedSet.Add(($_ -replace '\\', '/')) }
+
+$sarif = Get-Content $reportPath -Raw | ConvertFrom-Json
+Remove-Item $reportPath -Force -ErrorAction SilentlyContinue
+
+$results = @($sarif.runs[0].results | Where-Object {
+        $_.level -eq 'warning' -and
+        $_.ruleId -notin $IgnoredRules
+    })
+
+# Only fail for issues in files that were actually staged (filename-wildcard
+# include may match same-named files in other folders).
+$failures = @($results | Where-Object {
+        $uri = $_.locations[0].physicalLocation.artifactLocation.uri -replace '\\', '/'
+        $stagedSet.Contains($uri)
+    })
+
+if ($failures.Count -eq 0) {
+    Write-Host "pre-commit: no blocking issues in staged files. ✔" -ForegroundColor Green
+    exit 0
+}
+
+Write-Host ""
+Write-Host "pre-commit: $($failures.Count) blocking issue(s) in staged files:" -ForegroundColor Red
+Write-Host ""
+
+$failures | Sort-Object { $_.locations[0].physicalLocation.artifactLocation.uri } | ForEach-Object {
+    $loc = $_.locations[0].physicalLocation
+    $file = $loc.artifactLocation.uri
+    $line = $loc.region.startLine
+    "  {0}:{1}  [{2}]  {3}" -f $file, $line, $_.ruleId, $_.message.text
+} | Write-Host
+
+Write-Host ""
+Write-Host "Fix the issues above and re-stage, or bypass with: git commit --no-verify" -ForegroundColor Yellow
+exit 1

--- a/scripts/precommit-inspect.ps1
+++ b/scripts/precommit-inspect.ps1
@@ -63,44 +63,70 @@ if (-not $stagedFiles) {
     exit 0
 }
 
-function Ensure-JbOnPath {
-    if (Get-Command jb -ErrorAction SilentlyContinue) { return $true }
+function Ensure-Jb {
+    # Prefer the manifest-pinned local tool (`dotnet jb`) over a globally-
+    # installed `jb`, so the gate runs the exact version recorded in
+    # .config/dotnet-tools.json. Returns a hashtable describing how to invoke
+    # the tool: @{ Command = 'dotnet'|'jb'; Prefix = @('jb') | @() }.
+    $manifest = Join-Path $repoRoot '.config/dotnet-tools.json'
+    if ((Test-Path $manifest) -and (Get-Command dotnet -ErrorAction SilentlyContinue)) {
+        if (-not $script:JbRestored) {
+            & dotnet tool restore 2>&1 | Out-Null
+            if ($LASTEXITCODE -ne 0) {
+                Write-Warning "pre-commit: 'dotnet tool restore' failed; falling back to global jb if present."
+            } else {
+                $script:JbRestored = $true
+            }
+        }
+        if ($script:JbRestored) {
+            return @{ Command = 'dotnet'; Prefix = @('jb') }
+        }
+    }
 
-    # JetBrains.ReSharper.GlobalTools installs to the dotnet tools directory,
-    # which is on PATH by default on most setups but not always in a fresh
-    # shell. Probe the canonical location and prepend it for this run.
+    # Fallback: globally installed `jb` (legacy / user choice).
+    if (Get-Command jb -ErrorAction SilentlyContinue) {
+        return @{ Command = 'jb'; Prefix = @() }
+    }
     $toolsDir = if ($IsWindows) {
         Join-Path $env:USERPROFILE '.dotnet\tools'
     } else {
         Join-Path $HOME '.dotnet/tools'
     }
-    if (Test-Path (Join-Path $toolsDir (if ($IsWindows) { 'jb.exe' } else { 'jb' }))) {
+    $jbBin = Join-Path $toolsDir (if ($IsWindows) { 'jb.exe' } else { 'jb' })
+    if (Test-Path $jbBin) {
         $env:PATH = "$toolsDir$([IO.Path]::PathSeparator)$env:PATH"
-        if (Get-Command jb -ErrorAction SilentlyContinue) { return $true }
+        if (Get-Command jb -ErrorAction SilentlyContinue) {
+            return @{ Command = 'jb'; Prefix = @() }
+        }
     }
-    return $false
+    return $null
 }
 
-if (-not (Ensure-JbOnPath)) {
+$jb = Ensure-Jb
+if ($null -eq $jb) {
     if ($SkipAutoInstall) {
-        Write-Warning "pre-commit: 'jb' not on PATH and -SkipAutoInstall set; skipping inspection."
+        Write-Warning "pre-commit: 'jb' not available and -SkipAutoInstall set; skipping inspection."
         exit 0
     }
     if (-not (Get-Command dotnet -ErrorAction SilentlyContinue)) {
         Write-Warning "pre-commit: neither 'jb' nor 'dotnet' on PATH; skipping inspection."
-        Write-Warning "Install .NET SDK + 'dotnet tool install -g JetBrains.ReSharper.GlobalTools' to enable."
+        Write-Warning "Install the .NET SDK and run 'dotnet tool restore' from the repo root to enable."
         exit 0
     }
 
-    Write-Host "pre-commit: 'jb' not found, installing JetBrains.ReSharper.GlobalTools (one-time)..." -ForegroundColor Yellow
+    # No manifest + dotnet present — last-resort one-time global install.
+    # The manifest path above is the preferred path; this branch only fires
+    # in repos that haven't (yet) added .config/dotnet-tools.json.
+    Write-Host "pre-commit: 'jb' not found and no tool manifest; installing JetBrains.ReSharper.GlobalTools (one-time)..." -ForegroundColor Yellow
     & dotnet tool install -g JetBrains.ReSharper.GlobalTools 2>&1 | Out-Host
     if ($LASTEXITCODE -ne 0) {
         Write-Warning "pre-commit: auto-install failed; skipping inspection."
         Write-Warning "Run manually: dotnet tool install -g JetBrains.ReSharper.GlobalTools"
         exit 0
     }
-    if (-not (Ensure-JbOnPath)) {
-        Write-Warning "pre-commit: 'jb' still not on PATH after install; skipping inspection."
+    $jb = Ensure-Jb
+    if ($null -eq $jb) {
+        Write-Warning "pre-commit: 'jb' still not available after install; skipping inspection."
         Write-Warning "Add `$HOME/.dotnet/tools (or %USERPROFILE%\.dotnet\tools) to PATH and retry."
         exit 0
     }
@@ -115,6 +141,7 @@ $reportPath = Join-Path ([IO.Path]::GetTempPath()) "precommit-inspect-$([Guid]::
 $includeMask = ($stagedFiles | ForEach-Object { "**/" + (Split-Path $_ -Leaf) } | Sort-Object -Unique) -join ';'
 
 $jbArgs = @(
+    'inspectcode',
     $Solution,
     "--output=$reportPath",
     "--include=$includeMask",
@@ -123,16 +150,36 @@ $jbArgs = @(
 )
 
 $sw = [Diagnostics.Stopwatch]::StartNew()
-& jb inspectcode @jbArgs | Out-Null
+$invokeArgs = $jb.Prefix + $jbArgs
+& $jb.Command @invokeArgs | Out-Null
 $jbExit = $LASTEXITCODE
 $sw.Stop()
 Write-Host "pre-commit: inspection finished in $([int]$sw.Elapsed.TotalSeconds)s." -ForegroundColor DarkGray
 
+# Build a copy/paste-safe rerun command. Quote any arg that contains whitespace
+# or shell metacharacters so the temp SARIF path (and any other surprising
+# value) round-trips correctly.
+function Format-ShellArg {
+    param([Parameter(Mandatory)][string]$Value)
+    # Quote any value containing whitespace or shell metacharacters so the
+    # temp SARIF path (and other surprising values) round-trip correctly.
+    # Build the metachar list in a char-class via [regex] to avoid quote-
+    # escaping headaches inside a PowerShell string literal.
+    $needsQuoting = [regex]::IsMatch($Value, '[\s"\\$`!()*?\[\]{}|<>;&#~'']')
+    if (-not $needsQuoting) { return $Value }
+    # Prefer single quotes; if the value contains one, fall back to double
+    # quoting with backtick-escaped specials.
+    if ($Value -notmatch "'") { return "'" + $Value + "'" }
+    return '"' + ($Value -replace '([\\"`$])','`$1') + '"'
+}
+$rerunParts = @($jb.Command) + $jb.Prefix + $jbArgs
+$rerunCmd = ($rerunParts | ForEach-Object { Format-ShellArg $_ }) -join ' '
+
 if ($jbExit -ne 0) {
     Write-Host "" -ForegroundColor Red
-    Write-Host "pre-commit: 'jb inspectcode' exited with code $jbExit (restore/build/tool failure)." -ForegroundColor Red
+    Write-Host "pre-commit: '$($jb.Command) $($jb.Prefix -join ' ') inspectcode' exited with code $jbExit (restore/build/tool failure)." -ForegroundColor Red
     Write-Host "  Re-run manually to see the full output:" -ForegroundColor Yellow
-    Write-Host "    jb inspectcode $($jbArgs -join ' ')" -ForegroundColor Yellow
+    Write-Host "    $rerunCmd" -ForegroundColor Yellow
     Write-Host "  Bypass with: git commit --no-verify" -ForegroundColor Yellow
     exit 1
 }

--- a/scripts/precommit-inspect.ps1
+++ b/scripts/precommit-inspect.ps1
@@ -148,11 +148,44 @@ if ($null -eq $jb) {
 
 Write-Host "pre-commit: inspecting $($stagedFiles.Count) staged .cs file(s)..." -ForegroundColor Cyan
 
+# The hook must inspect the exact content being committed (the index), not
+# the working tree. If a developer has unstaged edits in a staged file, a
+# working-tree inspection would either fail the commit on code that is not
+# being committed, or — worse — pass after an unstaged fix while committing
+# the still-broken staged version. Stash unstaged changes (and untracked
+# files) with --keep-index so the working tree matches the index for the
+# duration of the inspection, then restore afterward in `finally`.
+#
+# Detect a no-op stash by comparing refs/stash before and after: an actual
+# stash entry advances that ref, while "nothing to stash" leaves it (or its
+# absence) untouched. Without this we would `stash pop` someone else's
+# previously-stashed work and corrupt their tree.
+$preStashSha = (& git rev-parse --verify --quiet refs/stash 2>$null)
+& git stash push --keep-index --include-untracked --quiet -m 'precommit-inspect: working-tree snapshot' 2>$null | Out-Null
+$postStashSha = (& git rev-parse --verify --quiet refs/stash 2>$null)
+$stashed = ($postStashSha -and ($postStashSha -ne $preStashSha))
+
 $reportPath = Join-Path ([IO.Path]::GetTempPath()) "precommit-inspect-$([Guid]::NewGuid()).sarif"
 # Mirror to $script: so Remove-Report (which references $script:reportPath) can
 # actually find and delete the temp SARIF file on every exit path. Without this
 # the function's $script:reportPath would be $null and the temp file would leak.
 $script:reportPath = $reportPath
+
+# Helper invoked before every `exit` below — PowerShell `exit` skips `finally`,
+# so we explicitly run cleanup before each terminal path. Restores unstaged
+# edits + untracked files that we stashed above so the developer's working
+# tree survives the inspection (success or failure) intact.
+function Restore-WorkingTree {
+    if ($script:stashed) {
+        & git stash pop --quiet 2>$null | Out-Null
+        if ($LASTEXITCODE -ne 0) {
+            Write-Warning "pre-commit: 'git stash pop' failed — your unstaged changes are still in the stash."
+            Write-Warning "  Recover with: git stash list ; git stash pop"
+        }
+        $script:stashed = $false
+    }
+}
+$script:stashed = $stashed
 
 # --include uses file-name wildcards; we use **/<leaf> so patterns match the solution layout.
 $includeMask = ($stagedFiles | ForEach-Object { "**/" + (Split-Path $_ -Leaf) } | Sort-Object -Unique) -join ';'
@@ -176,10 +209,13 @@ Write-Host "pre-commit: inspection finished in $([int]$sw.Elapsed.TotalSeconds)s
 # Helper so the temp SARIF file is removed on every exit path — success,
 # parse error, jb failure, or missing report. PowerShell `exit` skips
 # enclosing `finally` blocks, so we explicitly cleanup before each `exit`.
+# Also restores any working-tree stash we created earlier, since every
+# `Remove-Report` site is downstream of the stash point.
 function Remove-Report {
     if ($script:reportPath -and (Test-Path $script:reportPath)) {
         Remove-Item $script:reportPath -Force -ErrorAction SilentlyContinue
     }
+    Restore-WorkingTree
 }
 
 # Build a copy/paste-safe rerun command. Quote any arg that contains whitespace
@@ -289,6 +325,7 @@ $failures = @($results | Where-Object {
     })
 
 if ($failures.Count -eq 0) {
+    Restore-WorkingTree
     Write-Host "pre-commit: no blocking issues in staged files. ✔" -ForegroundColor Green
     exit 0
 }
@@ -306,4 +343,5 @@ $failures | Sort-Object { $_.locations[0].physicalLocation.artifactLocation.uri 
 
 Write-Host ""
 Write-Host "Fix the issues above and re-stage, or bypass with: git commit --no-verify" -ForegroundColor Yellow
+Restore-WorkingTree
 exit 1

--- a/scripts/precommit-inspect.ps1
+++ b/scripts/precommit-inspect.ps1
@@ -149,6 +149,10 @@ if ($null -eq $jb) {
 Write-Host "pre-commit: inspecting $($stagedFiles.Count) staged .cs file(s)..." -ForegroundColor Cyan
 
 $reportPath = Join-Path ([IO.Path]::GetTempPath()) "precommit-inspect-$([Guid]::NewGuid()).sarif"
+# Mirror to $script: so Remove-Report (which references $script:reportPath) can
+# actually find and delete the temp SARIF file on every exit path. Without this
+# the function's $script:reportPath would be $null and the temp file would leak.
+$script:reportPath = $reportPath
 
 # --include uses file-name wildcards; we use **/<leaf> so patterns match the solution layout.
 $includeMask = ($stagedFiles | ForEach-Object { "**/" + (Split-Path $_ -Leaf) } | Sort-Object -Unique) -join ';'

--- a/scripts/precommit-inspect.ps1
+++ b/scripts/precommit-inspect.ps1
@@ -223,7 +223,20 @@ if ($badSep.Count -gt 0) {
     Write-Host "  Bypass in an emergency with: git commit --no-verify" -ForegroundColor Yellow
     exit 1
 }
-$includeMask = ($stagedFiles | ForEach-Object { "**/" + (Split-Path $_ -Leaf) } | Sort-Object -Unique) -join ';'
+# De-duplicate leaf basenames with the same comparer used for $stagedSet
+# ($pathComparer). PowerShell's default `Sort-Object -Unique` is case-
+# insensitive on every platform, but on POSIX filesystems Foo.cs and foo.cs
+# are distinct files — using the default comparer there would collapse the
+# two leaves into one mask and silently skip one of the files.
+$leafSet = [System.Collections.Generic.HashSet[string]]::new($pathComparer)
+$includeMaskParts = New-Object System.Collections.Generic.List[string]
+foreach ($f in $stagedFiles) {
+    $leaf = Split-Path $f -Leaf
+    if ($leafSet.Add($leaf)) {
+        [void]$includeMaskParts.Add("**/$leaf")
+    }
+}
+$includeMask = $includeMaskParts -join ';'
 
 $jbArgs = @(
     'inspectcode',

--- a/scripts/precommit-inspect.ps1
+++ b/scripts/precommit-inspect.ps1
@@ -7,9 +7,18 @@
     Fails the commit when any warning-level Rider/Roslyn inspection fires in
     a staged file. Note-level suggestions are ignored.
 
-    First run: if `jb` is missing and `dotnet` is on PATH, this script will
-    install JetBrains.ReSharper.GlobalTools as a global tool automatically.
-    Pass `-SkipAutoInstall` to disable that behavior.
+    Tool resolution (in order):
+      1. If `.config/dotnet-tools.json` exists and `dotnet` is on PATH, the
+         script runs `dotnet tool restore` and invokes `dotnet jb` — i.e.
+         the manifest-pinned local tool. This is the preferred path in
+         this repo and keeps every developer + CI on the same version.
+      2. Otherwise, falls back to a globally-installed `jb` (legacy).
+      3. If neither is available and `dotnet` is on PATH, performs a one-
+         time `dotnet tool install -g JetBrains.ReSharper.GlobalTools`
+         (only when no manifest is present). Pass `-SkipAutoInstall` to
+         disable that fallback install. `-SkipAutoInstall` does NOT skip
+         the manifest-based `dotnet tool restore` — that path always
+         runs when a manifest is present.
 
     Bypass in an emergency with: git commit --no-verify
 
@@ -62,6 +71,10 @@ if (-not $stagedFiles) {
     Write-Host "pre-commit: no staged .cs files - skipping inspection." -ForegroundColor DarkGray
     exit 0
 }
+
+# Use case-sensitive comparisons on POSIX filesystems (Linux/macOS) where
+# Foo.cs and foo.cs are distinct files. Windows/NTFS is case-insensitive.
+$pathComparer = if ($IsWindows) { [StringComparer]::OrdinalIgnoreCase } else { [StringComparer]::Ordinal }
 
 function Ensure-Jb {
     # Prefer the manifest-pinned local tool (`dotnet jb`) over a globally-
@@ -156,6 +169,15 @@ $jbExit = $LASTEXITCODE
 $sw.Stop()
 Write-Host "pre-commit: inspection finished in $([int]$sw.Elapsed.TotalSeconds)s." -ForegroundColor DarkGray
 
+# Helper so the temp SARIF file is removed on every exit path — success,
+# parse error, jb failure, or missing report. PowerShell `exit` skips
+# enclosing `finally` blocks, so we explicitly cleanup before each `exit`.
+function Remove-Report {
+    if ($script:reportPath -and (Test-Path $script:reportPath)) {
+        Remove-Item $script:reportPath -Force -ErrorAction SilentlyContinue
+    }
+}
+
 # Build a copy/paste-safe rerun command. Quote any arg that contains whitespace
 # or shell metacharacters so the temp SARIF path (and any other surprising
 # value) round-trips correctly.
@@ -176,6 +198,7 @@ $rerunParts = @($jb.Command) + $jb.Prefix + $jbArgs
 $rerunCmd = ($rerunParts | ForEach-Object { Format-ShellArg $_ }) -join ' '
 
 if ($jbExit -ne 0) {
+    Remove-Report
     Write-Host "" -ForegroundColor Red
     Write-Host "pre-commit: '$($jb.Command) $($jb.Prefix -join ' ') inspectcode' exited with code $jbExit (restore/build/tool failure)." -ForegroundColor Red
     Write-Host "  Re-run manually to see the full output:" -ForegroundColor Yellow
@@ -185,17 +208,26 @@ if ($jbExit -ne 0) {
 }
 
 if (-not (Test-Path $reportPath)) {
+    # No report produced — nothing to clean up, but call Remove-Report for
+    # symmetry in case a partial file exists.
+    Remove-Report
     Write-Host "pre-commit: 'jb inspectcode' returned 0 but produced no report at $reportPath." -ForegroundColor Red
     Write-Host "  This usually means the include mask matched no files in the solution." -ForegroundColor Yellow
     Write-Host "  Bypass with: git commit --no-verify" -ForegroundColor Yellow
     exit 1
 }
 
-$stagedSet = [System.Collections.Generic.HashSet[string]]::new([StringComparer]::OrdinalIgnoreCase)
+$stagedSet = [System.Collections.Generic.HashSet[string]]::new($pathComparer)
 $stagedFiles | ForEach-Object { [void]$stagedSet.Add(($_ -replace '\\', '/')) }
 
-$sarif = Get-Content $reportPath -Raw | ConvertFrom-Json
-Remove-Item $reportPath -Force -ErrorAction SilentlyContinue
+try {
+    $sarif = Get-Content $reportPath -Raw | ConvertFrom-Json
+} catch {
+    Remove-Report
+    Write-Host "pre-commit: failed to parse SARIF report at ${reportPath}: $($_.Exception.Message)" -ForegroundColor Red
+    exit 1
+}
+Remove-Report
 
 # Normalize IgnoredRules: trim, drop empties, and split on commas in case a
 # single comma-separated string was passed (e.g., `-IgnoredRules "IDE0005, CA1822"`).

--- a/scripts/precommit-inspect.ps1
+++ b/scripts/precommit-inspect.ps1
@@ -81,22 +81,27 @@ function Ensure-Jb {
     # installed `jb`, so the gate runs the exact version recorded in
     # .config/dotnet-tools.json. Returns a hashtable describing how to invoke
     # the tool: @{ Command = 'dotnet'|'jb'; Prefix = @('jb') | @() }.
+    #
+    # When a manifest is present but `dotnet tool restore` fails, we MUST
+    # return $null instead of falling through to a globally-installed `jb`.
+    # Otherwise the gate would silently run a different (likely newer)
+    # InspectCode build than CI, defeating the pin. The fail-soft branch
+    # below (which fires on $null return) surfaces the restore error so
+    # the developer can fix it deliberately.
     $manifest = Join-Path $repoRoot '.config/dotnet-tools.json'
     if ((Test-Path $manifest) -and (Get-Command dotnet -ErrorAction SilentlyContinue)) {
         if (-not $script:JbRestored) {
             & dotnet tool restore 2>&1 | Out-Null
             if ($LASTEXITCODE -ne 0) {
-                Write-Warning "pre-commit: 'dotnet tool restore' failed; falling back to global jb if present."
-            } else {
-                $script:JbRestored = $true
+                Write-Warning "pre-commit: 'dotnet tool restore' failed; not falling back to global jb (manifest pin takes precedence)."
+                return $null
             }
+            $script:JbRestored = $true
         }
-        if ($script:JbRestored) {
-            return @{ Command = 'dotnet'; Prefix = @('jb') }
-        }
+        return @{ Command = 'dotnet'; Prefix = @('jb') }
     }
 
-    # Fallback: globally installed `jb` (legacy / user choice).
+    # No manifest — fall back to a globally-installed `jb` (legacy / user choice).
     if (Get-Command jb -ErrorAction SilentlyContinue) {
         return @{ Command = 'jb'; Prefix = @() }
     }

--- a/scripts/precommit-inspect.ps1
+++ b/scripts/precommit-inspect.ps1
@@ -179,11 +179,22 @@ $repoRootPosix = ($repoRoot -replace '\\', '/').TrimEnd('/')
 function Normalize-SarifUri {
     param([Parameter(Mandatory)][string]$Uri)
     $u = $Uri
-    if ($u -match '^file:/{2,3}') { $u = $u -replace '^file:/{2,3}', '/' }
+    # file:// URIs need [System.Uri] parsing to handle Windows-form
+    # `file:///C:/repo/...` correctly. A naive `^file:/{2,3}` -> '/'
+    # replace would yield '/C:/repo/...' which would never match
+    # $repoRootPosix on Windows.
+    if ($u -match '^file:') {
+        try {
+            $u = ([System.Uri]$u).LocalPath
+        } catch {
+            $u = $u -replace '^file:/{2,3}', ''
+        }
+    }
     $u = $u -replace '\\', '/'
     if ($u -like './*') { $u = $u.Substring(2) }
-    # Absolute path inside the repo root → strip prefix.
-    if ($u -like "$repoRootPosix/*") { $u = $u.Substring($repoRootPosix.Length + 1) }
+    # Absolute path inside the repo root → strip prefix (case-insensitive on Windows).
+    $cmp = if ($IsWindows) { [StringComparison]::OrdinalIgnoreCase } else { [StringComparison]::Ordinal }
+    if ($u.StartsWith("$repoRootPosix/", $cmp)) { $u = $u.Substring($repoRootPosix.Length + 1) }
     return $u.TrimStart('/')
 }
 

--- a/scripts/precommit-inspect.ps1
+++ b/scripts/precommit-inspect.ps1
@@ -65,7 +65,36 @@ if (-not $Solution) {
     $Solution = (Resolve-Path $candidates[0].FullName -Relative)
 }
 
-$stagedFiles = & git diff --cached --name-only --diff-filter=ACMR | Where-Object { $_ -like '*.cs' }
+# Use NUL-delimited output (`-z`) so a staged path containing a newline
+# survives intact instead of being split into two bogus entries. Git
+# permits CR/LF in path names. We then reject any path containing CR/LF
+# explicitly before further processing — the rest of the script (include
+# mask, staged-set membership, error messages) cannot represent CR/LF
+# safely, so fail closed in that case.
+$gitOutput = & git diff --cached -z --name-only --diff-filter=ACMR
+if ($LASTEXITCODE -ne 0) {
+    Write-Host "pre-commit: 'git diff --cached' failed (exit $LASTEXITCODE); skipping inspection." -ForegroundColor Red
+    exit 1
+}
+# A NUL-terminated list ends with an empty element after split; drop it.
+$stagedRaw = if ($gitOutput) { $gitOutput -split "`0" | Where-Object { $_ -ne '' } } else { @() }
+$stagedFiles = @($stagedRaw | Where-Object { $_ -like '*.cs' })
+
+$badNewline = @($stagedFiles | Where-Object { $_ -match "[`r`n]" })
+if ($badNewline.Count -gt 0) {
+    Write-Host ""
+    Write-Host "pre-commit: refusing to inspect — staged filename contains CR/LF, which cannot be safely represented in the include mask:" -ForegroundColor Red
+    $badNewline | ForEach-Object {
+        # Render the offending path as a literal escape so the CR/LF doesn't
+        # corrupt the terminal output itself.
+        $escaped = ($_ -replace "`r",'\r') -replace "`n",'\n'
+        Write-Host "  $escaped" -ForegroundColor Red
+    }
+    Write-Host ""
+    Write-Host "  Rename the file (or commit it under a different name) and re-stage." -ForegroundColor Yellow
+    Write-Host "  Bypass in an emergency with: git commit --no-verify" -ForegroundColor Yellow
+    exit 1
+}
 
 if (-not $stagedFiles) {
     Write-Host "pre-commit: no staged .cs files - skipping inspection." -ForegroundColor DarkGray

--- a/scripts/setup-hooks.ps1
+++ b/scripts/setup-hooks.ps1
@@ -1,0 +1,71 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    One-time setup for this repo's git hooks. Run once after cloning.
+
+.DESCRIPTION
+    Wires `git config core.hooksPath .githooks` so the shell pre-commit hook
+    runs on every commit. Also installs the JetBrains InspectCode CLI
+    (`jb`) as a global dotnet tool if it's not already on PATH and `dotnet`
+    is available.
+
+    Idempotent — safe to re-run.
+
+    Bypass an individual commit with: git commit --no-verify
+#>
+[CmdletBinding()]
+param(
+    [switch] $SkipJbInstall
+)
+
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = (& git rev-parse --show-toplevel 2>$null).Trim()
+if (-not $repoRoot) {
+    Write-Error "setup-hooks: not inside a git repo."
+    exit 1
+}
+Set-Location $repoRoot
+
+# 1. core.hooksPath -> .githooks
+$current = (& git config --local --get core.hooksPath 2>$null)
+if ($current -ne '.githooks') {
+    & git config --local core.hooksPath .githooks
+    Write-Host "✓ git config core.hooksPath = .githooks" -ForegroundColor Green
+} else {
+    Write-Host "✓ git config core.hooksPath already set to .githooks" -ForegroundColor DarkGray
+}
+
+# 2. shell hook executable bit (no-op on Windows / NTFS)
+$hook = Join-Path $repoRoot '.githooks/pre-commit'
+if ((Test-Path $hook) -and (-not $IsWindows)) {
+    & chmod +x $hook 2>$null
+}
+
+# 3. JetBrains.ReSharper.GlobalTools (`jb`)
+if ($SkipJbInstall) {
+    Write-Host "↷ skipping jb install (-SkipJbInstall)" -ForegroundColor DarkGray
+} elseif (Get-Command jb -ErrorAction SilentlyContinue) {
+    Write-Host "✓ jb already on PATH" -ForegroundColor DarkGray
+} elseif (-not (Get-Command dotnet -ErrorAction SilentlyContinue)) {
+    Write-Warning "dotnet not found on PATH. Install the .NET SDK then re-run this script."
+} else {
+    Write-Host "↻ installing JetBrains.ReSharper.GlobalTools (one-time)..." -ForegroundColor Yellow
+    & dotnet tool install -g JetBrains.ReSharper.GlobalTools 2>&1 | Out-Host
+    if ($LASTEXITCODE -ne 0) {
+        Write-Warning "jb install failed. Run manually: dotnet tool install -g JetBrains.ReSharper.GlobalTools"
+    } else {
+        $toolsDir = if ($IsWindows) {
+            Join-Path $env:USERPROFILE '.dotnet\tools'
+        } else {
+            Join-Path $HOME '.dotnet/tools'
+        }
+        Write-Host "✓ jb installed to $toolsDir" -ForegroundColor Green
+        if (-not (Get-Command jb -ErrorAction SilentlyContinue)) {
+            Write-Warning "Add $toolsDir to your PATH for jb to be discovered in new shells."
+        }
+    }
+}
+
+Write-Host ""
+Write-Host "Hooks ready. Bypass any single commit with: git commit --no-verify" -ForegroundColor Cyan

--- a/scripts/setup-hooks.ps1
+++ b/scripts/setup-hooks.ps1
@@ -5,9 +5,10 @@
 
 .DESCRIPTION
     Wires `git config core.hooksPath .githooks` so the shell pre-commit hook
-    runs on every commit. Also installs the JetBrains InspectCode CLI
-    (`jb`) as a global dotnet tool if it's not already on PATH and `dotnet`
-    is available.
+    runs on every commit. Then runs `dotnet tool restore` to install the
+    JetBrains InspectCode CLI (`jb`) at the version pinned in
+    `.config/dotnet-tools.json`. The tool is invoked locally as `dotnet jb`,
+    not as a global tool, so every developer + CI run the same version.
 
     Idempotent — safe to re-run.
 
@@ -15,7 +16,8 @@
 #>
 [CmdletBinding()]
 param(
-    [switch] $SkipJbInstall
+    [Alias('SkipJbInstall')]
+    [switch] $SkipJbRestore
 )
 
 $ErrorActionPreference = 'Stop'
@@ -47,8 +49,8 @@ if ((Test-Path $hook) -and (-not $IsWindows)) {
 #    so every developer + CI runs the exact same InspectCode version.
 #    `dotnet tool restore` is idempotent: it re-uses the existing install when
 #    the manifest version is already present.
-if ($SkipJbInstall) {
-    Write-Host "↷ skipping jb restore (-SkipJbInstall)" -ForegroundColor DarkGray
+if ($SkipJbRestore) {
+    Write-Host "↷ skipping jb restore (-SkipJbRestore)" -ForegroundColor DarkGray
 } elseif (-not (Get-Command dotnet -ErrorAction SilentlyContinue)) {
     Write-Warning "dotnet not found on PATH. Install the .NET SDK then re-run this script."
 } else {

--- a/scripts/setup-hooks.ps1
+++ b/scripts/setup-hooks.ps1
@@ -43,28 +43,29 @@ if ((Test-Path $hook) -and (-not $IsWindows)) {
     & chmod +x $hook 2>$null
 }
 
-# 3. JetBrains.ReSharper.GlobalTools (`jb`)
+# 3. JetBrains.ReSharper.GlobalTools (`jb`) — pinned via .config/dotnet-tools.json
+#    so every developer + CI runs the exact same InspectCode version.
+#    `dotnet tool restore` is idempotent: it re-uses the existing install when
+#    the manifest version is already present.
 if ($SkipJbInstall) {
-    Write-Host "↷ skipping jb install (-SkipJbInstall)" -ForegroundColor DarkGray
-} elseif (Get-Command jb -ErrorAction SilentlyContinue) {
-    Write-Host "✓ jb already on PATH" -ForegroundColor DarkGray
+    Write-Host "↷ skipping jb restore (-SkipJbInstall)" -ForegroundColor DarkGray
 } elseif (-not (Get-Command dotnet -ErrorAction SilentlyContinue)) {
     Write-Warning "dotnet not found on PATH. Install the .NET SDK then re-run this script."
 } else {
-    Write-Host "↻ installing JetBrains.ReSharper.GlobalTools (one-time)..." -ForegroundColor Yellow
-    & dotnet tool install -g JetBrains.ReSharper.GlobalTools 2>&1 | Out-Host
+    Write-Host "↻ dotnet tool restore (pinned via .config/dotnet-tools.json)..." -ForegroundColor Yellow
+    & dotnet tool restore 2>&1 | Out-Host
     if ($LASTEXITCODE -ne 0) {
-        Write-Warning "jb install failed. Run manually: dotnet tool install -g JetBrains.ReSharper.GlobalTools"
+        Write-Warning "dotnet tool restore failed. Run manually: dotnet tool restore"
     } else {
-        $toolsDir = if ($IsWindows) {
-            Join-Path $env:USERPROFILE '.dotnet\tools'
-        } else {
-            Join-Path $HOME '.dotnet/tools'
+        $manifestVersion = $null
+        $manifestPath = Join-Path $repoRoot '.config/dotnet-tools.json'
+        if (Test-Path $manifestPath) {
+            try {
+                $manifest = Get-Content $manifestPath -Raw | ConvertFrom-Json
+                $manifestVersion = $manifest.tools.'jetbrains.resharper.globaltools'.version
+            } catch { }
         }
-        Write-Host "✓ jb installed to $toolsDir" -ForegroundColor Green
-        if (-not (Get-Command jb -ErrorAction SilentlyContinue)) {
-            Write-Warning "Add $toolsDir to your PATH for jb to be discovered in new shells."
-        }
+        Write-Host "✓ jb restored$([string]::IsNullOrEmpty($manifestVersion) ? '' : " (version $manifestVersion)"); invoke as 'dotnet jb' or 'dotnet tool run jb'." -ForegroundColor Green
     }
 }
 

--- a/scripts/setup-hooks.ps1
+++ b/scripts/setup-hooks.ps1
@@ -20,11 +20,12 @@ param(
 
 $ErrorActionPreference = 'Stop'
 
-$repoRoot = (& git rev-parse --show-toplevel 2>$null).Trim()
-if (-not $repoRoot) {
+$repoRootRaw = & git rev-parse --show-toplevel 2>$null
+if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($repoRootRaw)) {
     Write-Error "setup-hooks: not inside a git repo."
     exit 1
 }
+$repoRoot = $repoRootRaw.Trim()
 Set-Location $repoRoot
 
 # 1. core.hooksPath -> .githooks


### PR DESCRIPTION
## Summary

Adds the JetBrains InspectCode quality gate that already runs in `rajfinancial`. Blocks commits and PRs that introduce warning-level Rider/Roslyn inspections in changed `.cs` files. Suggestion-level findings remain IDE-only noise.

## Files

- **`scripts/precommit-inspect.ps1`** — runs `jb inspectcode` on staged `.cs` files. Auto-detects `src/*.sln` (or repo-root `*.sln`). On first run, auto-installs `JetBrains.ReSharper.GlobalTools` if `dotnet` is on PATH and `jb` is missing. Pass `-SkipAutoInstall` to disable.
- **`scripts/setup-hooks.ps1`** — one-shot per-clone setup: `git config core.hooksPath .githooks` + `jb` install if missing. Idempotent. Run once after cloning:
  ```bash
  pwsh scripts/setup-hooks.ps1
  ```
- **`.githooks/pre-commit`** — POSIX `sh` shim that delegates to `pwsh`. Best-effort: silently skips if neither `pwsh` nor `powershell` is on PATH.
- **`.github/workflows/code-inspection.yml`** — CI gate on PRs to `master`/`develop`. Inspects only `.cs` files changed by the PR. Uploads SARIF artifact. `IGNORED_RULES` env var available for regression windows.

## Verified locally

- `pwsh scripts/setup-hooks.ps1` — wires `core.hooksPath` and confirms `jb` on PATH.
- Staged a real `.cs` change → hook ran `jb inspectcode` end-to-end (~30s) → cleared 'no blocking issues' on a clean diff.
- Full-repo inspection on `develop` HEAD: **24 warnings, 0 errors** — none of which were introduced by this PR. The 2 genuinely actionable ones (`CS1584` syntax error in XML doc `cref` at `Constants.cs:40`; `InvalidXmlDocComment` in a test) are pre-existing and will be cleaned up in a follow-up.

## Bypass

`git commit --no-verify` for the rare emergency. Auto-install can be opted out per-invocation with `-SkipAutoInstall`.

## Follow-ups (separate PRs)

- Mirror this onto `template-library` / `template-server` so newly created repos inherit the gate.
- Add `jetbrains-precommit-inspect` skill to `gh-misc-tools` for retro-fitting older repos.