### PR TITLE
feat(logging): add buffering ("dump-on-error") logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ public async Task ProcessAsync(ILogger<OrderService> logger, int orderId)
 }
 ```
 
-> **Dumped records always reach your sinks — no filter configuration required.** The error dump is
+> **Dumped records reach your sinks without extra filter configuration.** The error dump is
 > replayed **directly to the registered logging providers**, bypassing the
 > Microsoft.Extensions.Logging factory-level filters (the `Logging:LogLevel` category/provider rules).
 > That is deliberate: the whole point of a dump-on-error buffer is to surface the low-level context
@@ -134,6 +134,12 @@ public async Task ProcessAsync(ILogger<OrderService> logger, int orderId)
 > you need — buffered `Debug`/`Trace` still appears on error. One consequence: an error replays the
 > buffered context to **every** registered provider, even one whose own configured level would normally
 > exclude those records.
+>
+> **The edge case:** if no logging providers are registered (or a custom inner factory whose providers
+> weren't surfaced to the decorator), the replay target reaches nothing, so the buffered context can't
+> be dumped — only the triggering `Error`/`Critical` record falls back to the inner logger and follows
+> your live configuration. Any realistic setup with at least one provider (e.g. `AddConsole()`) dumps to
+> every registered sink.
 
 > **Replay fidelity.** Object-valued structured properties (e.g. `logger.LogDebug("processing {Order}",
 > order)`) are frozen to their `ToString()` text at log time so a later mutation can't change what the

--- a/README.md
+++ b/README.md
@@ -65,16 +65,20 @@ buffer only flushes manually).
 
 ### How records are routed
 
-Three configurable thresholds (`BufferLevel ≤ PassthroughLevel ≤ FlushLevel`) drive every record:
+Your host's existing live logging configuration (e.g. `Logging:LogLevel:Default`) stays **completely
+authoritative** for what is written live — buffering never overrides it. On top of that, two
+thresholds (`BufferLevel ≤ FlushLevel`) drive capture and the dump trigger:
 
 | Record level | Behaviour |
 |---|---|
+| written live by your configuration | written live as normal (buffering doesn't touch it) |
+| below the live threshold but `≥ BufferLevel` | captured into the active scope; emitted only on flush |
 | below `BufferLevel` | dropped |
-| `[BufferLevel, PassthroughLevel)` | captured into the active scope; emitted only on flush |
-| `[PassthroughLevel, FlushLevel)` | written through immediately (normal logging) |
-| at/above `FlushLevel` | flushes the scope (dumps the buffer), then writes the record |
+| `≥ FlushLevel`, inside a scope | flushes the scope (dumps the buffer + the triggering record) |
+| `≥ FlushLevel`, no scope | follows your live configuration (nothing to dump) |
 
-Defaults: `BufferLevel = Trace`, `PassthroughLevel = Information`, `FlushLevel = Error`.
+Defaults: `BufferLevel = Trace`, `FlushLevel = Error`. The live threshold is whatever your
+`Logging:LogLevel` configuration already says.
 
 ### Usage
 
@@ -88,15 +92,14 @@ services.AddLogging(logging =>
     logging.AddConsole();
     logging.AddBufferingLogging(o =>
     {
-        o.BufferLevel = LogLevel.Trace;
-        o.PassthroughLevel = LogLevel.Information;
-        o.FlushLevel = LogLevel.Error;
+        o.BufferLevel = LogLevel.Trace;  // how deep to capture
+        o.FlushLevel = LogLevel.Error;   // what triggers the dump
     });
 });
 ```
 
-By default `AddBufferingLogging` lowers the underlying logging filter for you (see the note below),
-so flushed `Debug`/`Trace` context actually reaches your sinks.
+Your `Logging:LogLevel` configuration continues to control live logging unchanged — set it to
+`Information` (or whatever you like) and `Debug`/`Trace` are buffered, then dumped on error.
 
 Wrap a logical operation (request, message handler, job) in a buffering scope:
 
@@ -123,17 +126,14 @@ public async Task ProcessAsync(ILogger<OrderService> logger, int orderId)
 }
 ```
 
-> **Making sure dumped records reach your sinks.** The buffering logger decorates your existing
-> logger, so dumped records still pass through the pipeline's own level filter. A plain
-> `SetMinimumLevel(LogLevel.Trace)` is **not** enough — a configuration-bound `Logging:LogLevel:Default`
-> rule takes precedence over the minimum level and would silently discard the dump. By default
-> `ConfigureUnderlyingFilter` is enabled, so `AddBufferingLogging` appends a winning no-category filter
-> rule at your `BufferLevel`. Caveats: it does not override more specific category/provider rules
-> (e.g. `Logging:LogLevel:MyApp`) — for those, set a `Trace` rule yourself; the logger emits a one-time
-> warning if it detects a dump is being filtered out. Because the rule is level-based, it also makes
-> passthrough-band records visible live where a higher configured default would have hidden them. The
-> decorator still holds back live emission of anything below `PassthroughLevel`, so your sinks stay
-> quiet until a flush. Set `ConfigureUnderlyingFilter = false` to manage the filter yourself.
+> **Dumped records always reach your sinks — no filter configuration required.** The error dump is
+> replayed **directly to the registered logging providers**, bypassing the
+> Microsoft.Extensions.Logging factory-level filters (the `Logging:LogLevel` category/provider rules).
+> That is deliberate: the whole point of a dump-on-error buffer is to surface the low-level context
+> your live configuration suppresses, so a plain `Logging:LogLevel:Default = Information` setting is all
+> you need — buffered `Debug`/`Trace` still appears on error. One consequence: an error replays the
+> buffered context to **every** registered provider, even one whose own configured level would normally
+> exclude those records.
 
 > **Replay fidelity.** Object-valued structured properties (e.g. `logger.LogDebug("processing {Order}",
 > order)`) are frozen to their `ToString()` text at log time so a later mutation can't change what the

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ dotnet add package JamesConsulting
 | `JamesConsulting.Cryptography` | Hashing/encoding helpers on top of `string` |
 | `JamesConsulting.Hosting` | `HostExtensions`, `IHostInitializer` / `IHostInitializerAsync` — run async one-shot startup work inside `IHost` before `RunAsync()` |
 | `JamesConsulting.IO` | `StreamExtensions` (read-to-end, copy with progress, etc.) |
+| `JamesConsulting.Logging` | Buffering ("dump-on-error") logger — buffers Debug/Trace per scope and dumps them to your sinks only when an error is logged. See [Buffering logger](#buffering-dump-on-error-logger). |
 | `JamesConsulting.Net` | `ConnectToSharedFolder` — UNC/SMB credential impersonation. `Connect()` is Windows-only and throws `PlatformNotSupportedException` on macOS/Linux; `Dispose()` and the finalizer are safe no-ops on non-Windows. |
 | `JamesConsulting.Reflection` | `TypeExtensions` (default value resolution, async-method detection), `MethodInfoExtensions` |
 | `JamesConsulting.Security` | `SecureStringExtensions`, additional `StringExtensions` |
@@ -48,6 +49,102 @@ All public APIs ship with XML documentation; downstream consumers get IntelliSen
 step-into debugging.
 
 📚 **Full API reference:** **<https://docs.jamesconsulting.biz/james-consulting-core/>** (generated with DocFX from `master`).
+
+---
+
+## Buffering ("dump-on-error") logger
+
+`JamesConsulting.Logging` adds a logger that **buffers low-level logs in memory and only writes them
+when something goes wrong**. During normal operation your sinks stay quiet; the moment an `Error` (or
+`Critical`) is logged, the whole buffer of `Debug`/`Trace` context leading up to the failure is
+dumped — so you get rich diagnostics exactly when you need them, without the noise (or cost) the rest
+of the time.
+
+This is the **auto-flush-on-error** trigger that .NET's built-in log buffering doesn't provide (its
+buffer only flushes manually).
+
+### How records are routed
+
+Three configurable thresholds (`BufferLevel ≤ PassthroughLevel ≤ FlushLevel`) drive every record:
+
+| Record level | Behaviour |
+|---|---|
+| below `BufferLevel` | dropped |
+| `[BufferLevel, PassthroughLevel)` | captured into the active scope; emitted only on flush |
+| `[PassthroughLevel, FlushLevel)` | written through immediately (normal logging) |
+| at/above `FlushLevel` | flushes the scope (dumps the buffer), then writes the record |
+
+Defaults: `BufferLevel = Trace`, `PassthroughLevel = Information`, `FlushLevel = Error`.
+
+### Usage
+
+```csharp
+using JamesConsulting.Logging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+services.AddLogging(logging =>
+{
+    logging.AddConsole();
+    logging.AddBufferingLogging(o =>
+    {
+        o.BufferLevel = LogLevel.Trace;
+        o.PassthroughLevel = LogLevel.Information;
+        o.FlushLevel = LogLevel.Error;
+    });
+});
+```
+
+By default `AddBufferingLogging` lowers the underlying logging filter for you (see the note below),
+so flushed `Debug`/`Trace` context actually reaches your sinks.
+
+Wrap a logical operation (request, message handler, job) in a buffering scope:
+
+```csharp
+public async Task ProcessAsync(ILogger<OrderService> logger, int orderId)
+{
+    using (LogBuffer.BeginScope())
+    {
+        logger.LogDebug("Loading order {OrderId}", orderId);     // buffered
+        logger.LogInformation("Order {OrderId} loaded", orderId); // written live
+
+        try
+        {
+            // ... work ...
+        }
+        catch (Exception ex)
+        {
+            // The buffered Debug record above is dumped first, then this error.
+            logger.LogError(ex, "Failed to process order {OrderId}", orderId);
+            throw;
+        }
+    }
+    // No error? The Debug record is discarded when the scope is disposed.
+}
+```
+
+> **Making sure dumped records reach your sinks.** The buffering logger decorates your existing
+> logger, so dumped records still pass through the pipeline's own level filter. A plain
+> `SetMinimumLevel(LogLevel.Trace)` is **not** enough — a configuration-bound `Logging:LogLevel:Default`
+> rule takes precedence over the minimum level and would silently discard the dump. By default
+> `ConfigureUnderlyingFilter` is enabled, so `AddBufferingLogging` appends a winning no-category filter
+> rule at your `BufferLevel`. Caveats: it does not override more specific category/provider rules
+> (e.g. `Logging:LogLevel:MyApp`) — for those, set a `Trace` rule yourself; the logger emits a one-time
+> warning if it detects a dump is being filtered out. Because the rule is level-based, it also makes
+> passthrough-band records visible live where a higher configured default would have hidden them. The
+> decorator still holds back live emission of anything below `PassthroughLevel`, so your sinks stay
+> quiet until a flush. Set `ConfigureUnderlyingFilter = false` to manage the filter yourself.
+
+> **Replay fidelity.** Object-valued structured properties (e.g. `logger.LogDebug("processing {Order}",
+> order)`) are frozen to their `ToString()` text at log time so a later mutation can't change what the
+> dump reports — a destructuring sink therefore receives the frozen text, not the live object. Scalar
+> values (strings, numbers, enums, `DateTime`, `Guid`, …) keep their original type. Records are replayed
+> in chronological order within a logical flow (nested scopes dump ancestors first); ordering is
+> best-effort under concurrent logging on the same scope.
+
+Buffering is AsyncLocal-scoped (it flows across `await`), thread-safe, and bounded by a ring buffer
+(default capacity 1000, drop-oldest on overflow). Buffered records do **not** capture
+`ILogger.BeginScope` state — matching the built-in .NET buffering.
 
 ---
 
@@ -101,48 +198,16 @@ dotnet test --filter "FullyQualifiedName~ObjectExtensionsTests.Mask"
 
 ---
 
-## Release process
-
-Releases follow GitFlow + semver. The `ci.yml` workflow has three jobs:
-
-| Trigger | Job | Output |
-|---|---|---|
-| Any push / PR / dispatch | `build-test` | Build, test, Sonar, coverage, preview pack (`*-ci.<run_number>`). Runs on every push. |
-| Push to `release/**` | `publish-rc` | Signs and publishes `<MAJOR>.<MINOR>.<PATCH>-rc.<run_number>` via NuGet Trusted Publishing. |
-| Push tag `v<MAJOR>.<MINOR>.<PATCH>` | `publish-stable` | Verifies tag matches `version.json` *and* that the tagged commit is reachable from `master`, then signs and publishes. Also creates a GitHub Release. |
-
-Cutting a release:
-
-```bash
-# 1. cut release branch from develop
-git switch develop && git pull
-git switch -c release/2.0.0
-git push -u origin release/2.0.0
-# -> publish-rc fires automatically: 2.0.0-rc.<run>
-
-# 2. when QA approves, merge release/2.0.0 -> master, then tag from master
-git switch master && git pull
-git tag v2.0.0
-git push origin v2.0.0
-# -> publish-stable fires: 2.0.0 stable + GitHub Release
-
-# 3. back-merge master -> develop
-git switch develop
-git merge --no-ff master
-git push
-```
-
-> The major.minor.patch number lives in [`version.json`](version.json). Bump it before opening the
-> release branch.
-
----
-
 ## Contributing
 
-1. Branch from `develop` (`feature/<name>` or `bugfix/<name>`).
+1. Branch from `develop` (`feature/<name>` or `bugfix/<name>`, or a child of another development
+   branch). All work targets `develop` — never branch from or push to `master`.
 2. Tests first — this repo follows BDD/TDD with a 90% coverage target.
 3. Run `dotnet build` and `dotnet test` locally before pushing.
 4. Open a PR into `develop`. CI must be green and Sonar quality gate must pass.
+
+> Releasing (cutting `release/**` branches, merging into `master`, and tagging) is restricted to the
+> maintainer, James Consulting LLC. Contributions stop at a PR into `develop`.
 
 Repo conventions live in [`AGENTS.md`](AGENTS.md).
 

--- a/src/JamesConsulting.Tests/JamesConsulting.Tests.csproj
+++ b/src/JamesConsulting.Tests/JamesConsulting.Tests.csproj
@@ -10,6 +10,8 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1"/>
         <PackageReference Include="FluentAssertions" Version="8.8.0"/>
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0"/>
+        <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.0"/>
         <PackageReference Include="NSubstitute" Version="5.3.0"/>
         <PackageReference Include="xunit" Version="2.9.3"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" PrivateAssets="all"/>

--- a/src/JamesConsulting.Tests/Logging/BufferingLoggerFactoryTests.cs
+++ b/src/JamesConsulting.Tests/Logging/BufferingLoggerFactoryTests.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using FluentAssertions;
+using JamesConsulting.Logging;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Xunit;
+
+namespace JamesConsulting.Tests.Logging;
+
+/// <summary>
+/// Unit tests for <see cref="BufferingLoggerFactory" />.
+/// </summary>
+public class BufferingLoggerFactoryTests
+{
+    /// <summary>
+    /// A null inner factory is rejected.
+    /// </summary>
+    [Fact]
+    public void ConstructorNullInnerThrows()
+    {
+        var act = () => new BufferingLoggerFactory(null!, new BufferingLoggerOptions());
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    /// <summary>
+    /// Null options are rejected.
+    /// </summary>
+    [Fact]
+    public void ConstructorNullOptionsThrows()
+    {
+        var act = () => new BufferingLoggerFactory(Substitute.For<ILoggerFactory>(), null!);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    /// <summary>
+    /// Invalid options are rejected by the constructor.
+    /// </summary>
+    [Fact]
+    public void ConstructorInvalidOptionsThrows()
+    {
+        var options = new BufferingLoggerOptions { BufferLevel = LogLevel.None };
+
+        var act = () => new BufferingLoggerFactory(Substitute.For<ILoggerFactory>(), options);
+
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    /// <summary>
+    /// <see cref="BufferingLoggerFactory.CreateLogger" /> wraps the inner logger in a
+    /// <see cref="BufferingLogger" />.
+    /// </summary>
+    [Fact]
+    public void CreateLoggerReturnsBufferingLogger()
+    {
+        var innerFactory = Substitute.For<ILoggerFactory>();
+        innerFactory.CreateLogger("cat").Returns(NullLogger.Instance);
+        var factory = new BufferingLoggerFactory(innerFactory, new BufferingLoggerOptions());
+
+        var logger = factory.CreateLogger("cat");
+
+        logger.Should().BeOfType<BufferingLogger>();
+        innerFactory.Received(1).CreateLogger("cat");
+    }
+
+    /// <summary>
+    /// <see cref="BufferingLoggerFactory.AddProvider" /> is delegated to the inner factory.
+    /// </summary>
+    [Fact]
+    public void AddProviderDelegatesToInner()
+    {
+        var innerFactory = Substitute.For<ILoggerFactory>();
+        var factory = new BufferingLoggerFactory(innerFactory, new BufferingLoggerOptions());
+        var provider = Substitute.For<ILoggerProvider>();
+
+        factory.AddProvider(provider);
+
+        innerFactory.Received(1).AddProvider(provider);
+    }
+
+    /// <summary>
+    /// <see cref="BufferingLoggerFactory.Dispose" /> is delegated to the inner factory.
+    /// </summary>
+    [Fact]
+    public void DisposeDelegatesToInner()
+    {
+        var innerFactory = Substitute.For<ILoggerFactory>();
+        var factory = new BufferingLoggerFactory(innerFactory, new BufferingLoggerOptions());
+
+        factory.Dispose();
+
+        innerFactory.Received(1).Dispose();
+    }
+}

--- a/src/JamesConsulting.Tests/Logging/BufferingLoggerFactoryTests.cs
+++ b/src/JamesConsulting.Tests/Logging/BufferingLoggerFactoryTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using FluentAssertions;
 using JamesConsulting.Logging;
 using Microsoft.Extensions.Logging;
@@ -13,13 +14,26 @@ namespace JamesConsulting.Tests.Logging;
 /// </summary>
 public class BufferingLoggerFactoryTests
 {
+    private static readonly ILoggerProvider[] NoProviders = Array.Empty<ILoggerProvider>();
+
     /// <summary>
     /// A null inner factory is rejected.
     /// </summary>
     [Fact]
     public void ConstructorNullInnerThrows()
     {
-        var act = () => new BufferingLoggerFactory(null!, new BufferingLoggerOptions());
+        var act = () => new BufferingLoggerFactory(null!, NoProviders, new BufferingLoggerOptions());
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    /// <summary>
+    /// A null providers collection is rejected.
+    /// </summary>
+    [Fact]
+    public void ConstructorNullProvidersThrows()
+    {
+        var act = () => new BufferingLoggerFactory(Substitute.For<ILoggerFactory>(), null!, new BufferingLoggerOptions());
 
         act.Should().Throw<ArgumentNullException>();
     }
@@ -30,7 +44,7 @@ public class BufferingLoggerFactoryTests
     [Fact]
     public void ConstructorNullOptionsThrows()
     {
-        var act = () => new BufferingLoggerFactory(Substitute.For<ILoggerFactory>(), null!);
+        var act = () => new BufferingLoggerFactory(Substitute.For<ILoggerFactory>(), NoProviders, null!);
 
         act.Should().Throw<ArgumentNullException>();
     }
@@ -43,7 +57,7 @@ public class BufferingLoggerFactoryTests
     {
         var options = new BufferingLoggerOptions { BufferLevel = LogLevel.None };
 
-        var act = () => new BufferingLoggerFactory(Substitute.For<ILoggerFactory>(), options);
+        var act = () => new BufferingLoggerFactory(Substitute.For<ILoggerFactory>(), NoProviders, options);
 
         act.Should().Throw<ArgumentOutOfRangeException>();
     }
@@ -57,7 +71,7 @@ public class BufferingLoggerFactoryTests
     {
         var innerFactory = Substitute.For<ILoggerFactory>();
         innerFactory.CreateLogger("cat").Returns(NullLogger.Instance);
-        var factory = new BufferingLoggerFactory(innerFactory, new BufferingLoggerOptions());
+        var factory = new BufferingLoggerFactory(innerFactory, NoProviders, new BufferingLoggerOptions());
 
         var logger = factory.CreateLogger("cat");
 
@@ -72,7 +86,7 @@ public class BufferingLoggerFactoryTests
     public void AddProviderDelegatesToInner()
     {
         var innerFactory = Substitute.For<ILoggerFactory>();
-        var factory = new BufferingLoggerFactory(innerFactory, new BufferingLoggerOptions());
+        var factory = new BufferingLoggerFactory(innerFactory, NoProviders, new BufferingLoggerOptions());
         var provider = Substitute.For<ILoggerProvider>();
 
         factory.AddProvider(provider);
@@ -87,10 +101,123 @@ public class BufferingLoggerFactoryTests
     public void DisposeDelegatesToInner()
     {
         var innerFactory = Substitute.For<ILoggerFactory>();
-        var factory = new BufferingLoggerFactory(innerFactory, new BufferingLoggerOptions());
+        var factory = new BufferingLoggerFactory(innerFactory, NoProviders, new BufferingLoggerOptions());
 
         factory.Dispose();
 
         innerFactory.Received(1).Dispose();
+    }
+
+    /// <summary>
+    /// A provider supplied at construction receives the error dump (buffered context and the
+    /// triggering record) directly, even though the inner logger would suppress the buffered level.
+    /// </summary>
+    [Fact]
+    public void SeededProviderReceivesDumpOnError()
+    {
+        var recorder = new RecordingProvider();
+        var innerFactory = Substitute.For<ILoggerFactory>();
+        innerFactory.CreateLogger("cat").Returns(new RecordingLogger(LogLevel.Information));
+        var factory = new BufferingLoggerFactory(innerFactory, new ILoggerProvider[] { recorder }, new BufferingLoggerOptions());
+
+        var logger = factory.CreateLogger("cat");
+
+        using (LogBuffer.BeginScope())
+        {
+            logger.LogDebug("ctx");
+            logger.LogError("boom");
+        }
+
+        recorder.Messages.Should().ContainInOrder("ctx", "boom");
+    }
+
+    /// <summary>
+    /// A provider added after construction via <see cref="BufferingLoggerFactory.AddProvider" /> also
+    /// participates in the error dump, because the replay target snapshots the live provider set.
+    /// </summary>
+    [Fact]
+    public void LateAddedProviderReceivesDumpOnError()
+    {
+        var recorder = new RecordingProvider();
+        var innerFactory = Substitute.For<ILoggerFactory>();
+        innerFactory.CreateLogger("cat").Returns(new RecordingLogger(LogLevel.Information));
+        var factory = new BufferingLoggerFactory(innerFactory, NoProviders, new BufferingLoggerOptions());
+
+        var logger = factory.CreateLogger("cat");
+        factory.AddProvider(recorder);
+
+        using (LogBuffer.BeginScope())
+        {
+            logger.LogDebug("ctx");
+            logger.LogError("boom");
+        }
+
+        recorder.Messages.Should().ContainInOrder("ctx", "boom");
+    }
+
+    /// <summary>
+    /// When the replay target reaches no providers (for example a custom inner factory whose
+    /// providers were not supplied to the buffering factory), a scoped error must not be lost: the
+    /// triggering record falls back to the inner logger. The buffered context cannot be surfaced,
+    /// because the inner filter that hid it live still applies.
+    /// </summary>
+    [Fact]
+    public void ScopedErrorFallsBackToInnerWhenNoReplayProviders()
+    {
+        var innerLogger = new RecordingLogger(LogLevel.Information);
+        var innerFactory = Substitute.For<ILoggerFactory>();
+        innerFactory.CreateLogger("cat").Returns(innerLogger);
+        var factory = new BufferingLoggerFactory(innerFactory, NoProviders, new BufferingLoggerOptions());
+
+        var logger = factory.CreateLogger("cat");
+
+        using (LogBuffer.BeginScope())
+        {
+            logger.LogDebug("ctx");
+            logger.LogError("boom");
+        }
+
+        innerLogger.Records.Should().ContainSingle(r => r.Level == LogLevel.Error && r.Message == "boom");
+        innerLogger.Records.Should().NotContain(r => r.Level == LogLevel.Debug);
+    }
+
+    private sealed class RecordingProvider : ILoggerProvider
+    {
+        public ConcurrentQueue<string> Messages { get; } = new();
+
+        public ILogger CreateLogger(string categoryName) => new ProviderLogger(Messages);
+
+        public void Dispose()
+        {
+        }
+
+        private sealed class ProviderLogger : ILogger
+        {
+            private readonly ConcurrentQueue<string> messages;
+
+            public ProviderLogger(ConcurrentQueue<string> messages) => this.messages = messages;
+
+            public IDisposable BeginScope<TState>(TState state)
+                where TState : notnull => NullScope.Instance;
+
+            public bool IsEnabled(LogLevel logLevel) => true;
+
+            public void Log<TState>(
+                LogLevel logLevel,
+                EventId eventId,
+                TState state,
+                Exception? exception,
+                Func<TState, Exception?, string> formatter) =>
+                messages.Enqueue(formatter(state, exception));
+
+            private sealed class NullScope : IDisposable
+            {
+                public static readonly NullScope Instance = new();
+
+                public void Dispose()
+                {
+                }
+            }
+        }
     }
 }

--- a/src/JamesConsulting.Tests/Logging/BufferingLoggerOptionsTests.cs
+++ b/src/JamesConsulting.Tests/Logging/BufferingLoggerOptionsTests.cs
@@ -1,0 +1,125 @@
+﻿using System;
+using FluentAssertions;
+using JamesConsulting.Logging;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace JamesConsulting.Tests.Logging;
+
+/// <summary>
+/// Unit tests for <see cref="BufferingLoggerOptions" /> validation.
+/// </summary>
+public class BufferingLoggerOptionsTests
+{
+    /// <summary>
+    /// The default options satisfy the required invariant.
+    /// </summary>
+    [Fact]
+    public void ValidateDefaultsDoesNotThrow()
+    {
+        var options = new BufferingLoggerOptions();
+
+        var act = options.Validate;
+
+        act.Should().NotThrow();
+    }
+
+    /// <summary>
+    /// Defaults match the documented values.
+    /// </summary>
+    [Fact]
+    public void DefaultsAreExpectedValues()
+    {
+        var options = new BufferingLoggerOptions();
+
+        options.BufferLevel.Should().Be(LogLevel.Trace);
+        options.PassthroughLevel.Should().Be(LogLevel.Information);
+        options.FlushLevel.Should().Be(LogLevel.Error);
+        options.SuspendBufferingAfterFlush.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// Any threshold set to <see cref="LogLevel.None" /> is rejected.
+    /// </summary>
+    /// <param name="which">Which threshold to set to None.</param>
+    [Theory]
+    [InlineData("buffer")]
+    [InlineData("passthrough")]
+    [InlineData("flush")]
+    public void ValidateRejectsNone(string which)
+    {
+        var options = new BufferingLoggerOptions();
+        switch (which)
+        {
+            case "buffer":
+                options.BufferLevel = LogLevel.None;
+                break;
+            case "passthrough":
+                options.PassthroughLevel = LogLevel.None;
+                break;
+            default:
+                options.FlushLevel = LogLevel.None;
+                break;
+        }
+
+        var act = options.Validate;
+
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    /// <summary>
+    /// A passthrough level below the buffer level violates the invariant.
+    /// </summary>
+    [Fact]
+    public void ValidateRejectsPassthroughBelowBuffer()
+    {
+        var options = new BufferingLoggerOptions
+        {
+            BufferLevel = LogLevel.Information,
+            PassthroughLevel = LogLevel.Debug,
+            FlushLevel = LogLevel.Error,
+        };
+
+        var act = options.Validate;
+
+        act.Should().Throw<ArgumentOutOfRangeException>()
+            .Which.ParamName.Should().Be(nameof(BufferingLoggerOptions.PassthroughLevel));
+    }
+
+    /// <summary>
+    /// A flush level below the passthrough level violates the invariant.
+    /// </summary>
+    [Fact]
+    public void ValidateRejectsFlushBelowPassthrough()
+    {
+        var options = new BufferingLoggerOptions
+        {
+            BufferLevel = LogLevel.Trace,
+            PassthroughLevel = LogLevel.Warning,
+            FlushLevel = LogLevel.Information,
+        };
+
+        var act = options.Validate;
+
+        act.Should().Throw<ArgumentOutOfRangeException>()
+            .Which.ParamName.Should().Be(nameof(BufferingLoggerOptions.FlushLevel));
+    }
+
+    /// <summary>
+    /// Equal thresholds are allowed (the invariant uses &lt;=).
+    /// </summary>
+    [Fact]
+    public void ValidateAllowsEqualThresholds()
+    {
+        var options = new BufferingLoggerOptions
+        {
+            BufferLevel = LogLevel.Information,
+            PassthroughLevel = LogLevel.Information,
+            FlushLevel = LogLevel.Information,
+        };
+
+        var act = options.Validate;
+
+        act.Should().NotThrow();
+    }
+}

--- a/src/JamesConsulting.Tests/Logging/BufferingLoggerOptionsTests.cs
+++ b/src/JamesConsulting.Tests/Logging/BufferingLoggerOptionsTests.cs
@@ -33,18 +33,16 @@ public class BufferingLoggerOptionsTests
         var options = new BufferingLoggerOptions();
 
         options.BufferLevel.Should().Be(LogLevel.Trace);
-        options.PassthroughLevel.Should().Be(LogLevel.Information);
         options.FlushLevel.Should().Be(LogLevel.Error);
         options.SuspendBufferingAfterFlush.Should().BeTrue();
     }
 
     /// <summary>
-    /// Any threshold set to <see cref="LogLevel.None" /> is rejected.
+    /// Either threshold set to <see cref="LogLevel.None" /> is rejected.
     /// </summary>
     /// <param name="which">Which threshold to set to None.</param>
     [Theory]
     [InlineData("buffer")]
-    [InlineData("passthrough")]
     [InlineData("flush")]
     public void ValidateRejectsNone(string which)
     {
@@ -53,9 +51,6 @@ public class BufferingLoggerOptionsTests
         {
             case "buffer":
                 options.BufferLevel = LogLevel.None;
-                break;
-            case "passthrough":
-                options.PassthroughLevel = LogLevel.None;
                 break;
             default:
                 options.FlushLevel = LogLevel.None;
@@ -68,34 +63,14 @@ public class BufferingLoggerOptionsTests
     }
 
     /// <summary>
-    /// A passthrough level below the buffer level violates the invariant.
+    /// A flush level below the buffer level violates the invariant.
     /// </summary>
     [Fact]
-    public void ValidateRejectsPassthroughBelowBuffer()
+    public void ValidateRejectsFlushBelowBuffer()
     {
         var options = new BufferingLoggerOptions
         {
-            BufferLevel = LogLevel.Information,
-            PassthroughLevel = LogLevel.Debug,
-            FlushLevel = LogLevel.Error,
-        };
-
-        var act = options.Validate;
-
-        act.Should().Throw<ArgumentOutOfRangeException>()
-            .Which.ParamName.Should().Be(nameof(BufferingLoggerOptions.PassthroughLevel));
-    }
-
-    /// <summary>
-    /// A flush level below the passthrough level violates the invariant.
-    /// </summary>
-    [Fact]
-    public void ValidateRejectsFlushBelowPassthrough()
-    {
-        var options = new BufferingLoggerOptions
-        {
-            BufferLevel = LogLevel.Trace,
-            PassthroughLevel = LogLevel.Warning,
+            BufferLevel = LogLevel.Warning,
             FlushLevel = LogLevel.Information,
         };
 
@@ -114,7 +89,6 @@ public class BufferingLoggerOptionsTests
         var options = new BufferingLoggerOptions
         {
             BufferLevel = LogLevel.Information,
-            PassthroughLevel = LogLevel.Information,
             FlushLevel = LogLevel.Information,
         };
 

--- a/src/JamesConsulting.Tests/Logging/BufferingLoggerTests.cs
+++ b/src/JamesConsulting.Tests/Logging/BufferingLoggerTests.cs
@@ -1,0 +1,462 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using JamesConsulting.Logging;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace JamesConsulting.Tests.Logging;
+
+/// <summary>
+/// Unit tests for <see cref="BufferingLogger" /> routing behaviour, including dump-on-error.
+/// </summary>
+public class BufferingLoggerTests
+{
+    private readonly RecordingLogger inner = new();
+
+    private BufferingLogger CreateLogger(Action<BufferingLoggerOptions>? configure = null)
+    {
+        var options = new BufferingLoggerOptions();
+        configure?.Invoke(options);
+        return new BufferingLogger(inner, options);
+    }
+
+    /// <summary>
+    /// A null inner logger is rejected.
+    /// </summary>
+    [Fact]
+    public void ConstructorNullInnerThrows()
+    {
+        var act = () => new BufferingLogger(null!, new BufferingLoggerOptions());
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    /// <summary>
+    /// Null options are rejected.
+    /// </summary>
+    [Fact]
+    public void ConstructorNullOptionsThrows()
+    {
+        var act = () => new BufferingLogger(inner, null!);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    /// <summary>
+    /// Invalid options are rejected by the constructor.
+    /// </summary>
+    [Fact]
+    public void ConstructorInvalidOptionsThrows()
+    {
+        var options = new BufferingLoggerOptions { FlushLevel = LogLevel.None };
+
+        var act = () => new BufferingLogger(inner, options);
+
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    /// <summary>
+    /// Passthrough-level records are written through immediately, even without a scope.
+    /// </summary>
+    [Fact]
+    public void InformationIsWrittenLive()
+    {
+        var logger = CreateLogger();
+
+        logger.LogInformation("hello");
+
+        inner.Records.Should().ContainSingle().Which.Message.Should().Be("hello");
+    }
+
+    /// <summary>
+    /// Buffer-range records are dropped when no scope is active.
+    /// </summary>
+    [Fact]
+    public void DebugWithoutScopeIsDropped()
+    {
+        var logger = CreateLogger();
+
+        logger.LogDebug("debug");
+
+        inner.Records.Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// Buffer-range records are held until a flush occurs.
+    /// </summary>
+    [Fact]
+    public void DebugWithinScopeIsBufferedNotWritten()
+    {
+        var logger = CreateLogger();
+
+        using var scope = LogBuffer.BeginScope();
+        logger.LogDebug("debug");
+
+        inner.Records.Should().BeEmpty();
+        scope.Count.Should().Be(1);
+    }
+
+    /// <summary>
+    /// An error dumps the buffered context first, in order, then writes the triggering record.
+    /// </summary>
+    [Fact]
+    public void ErrorDumpsBufferedContextThenError()
+    {
+        var logger = CreateLogger();
+
+        using (LogBuffer.BeginScope())
+        {
+            logger.LogDebug("first");
+            logger.LogDebug("second");
+            logger.LogInformation("info");
+            logger.LogError("boom");
+        }
+
+        inner.Records.Select(r => r.Message).Should()
+            .ContainInOrder("info", "first", "second", "boom");
+        inner.Records.Select(r => r.Level).Should()
+            .ContainInOrder(LogLevel.Information, LogLevel.Debug, LogLevel.Debug, LogLevel.Error);
+    }
+
+    /// <summary>
+    /// Records below the buffer level are always dropped, even inside a scope.
+    /// </summary>
+    [Fact]
+    public void BelowBufferLevelIsDropped()
+    {
+        var logger = CreateLogger(o => o.BufferLevel = LogLevel.Debug);
+
+        using var scope = LogBuffer.BeginScope();
+        logger.LogTrace("trace");
+        logger.LogError("boom");
+
+        inner.Records.Select(r => r.Message).Should().Equal("boom");
+    }
+
+    /// <summary>
+    /// After a flush, buffer-range records are written live when suspend-after-flush is enabled.
+    /// </summary>
+    [Fact]
+    public void SuspendAfterFlushWritesSubsequentDebugLive()
+    {
+        var logger = CreateLogger(o => o.SuspendBufferingAfterFlush = true);
+
+        using (LogBuffer.BeginScope())
+        {
+            logger.LogError("boom");
+            logger.LogDebug("after");
+        }
+
+        inner.Records.Select(r => r.Message).Should().Equal("boom", "after");
+    }
+
+    /// <summary>
+    /// When suspend-after-flush is disabled, the scope resumes buffering and only dumps on the next error.
+    /// </summary>
+    [Fact]
+    public void NoSuspendAfterFlushResumesBuffering()
+    {
+        var logger = CreateLogger(o => o.SuspendBufferingAfterFlush = false);
+
+        using (LogBuffer.BeginScope())
+        {
+            logger.LogError("boom1");
+            logger.LogDebug("after");
+
+            inner.Records.Select(r => r.Message).Should().Equal("boom1");
+
+            logger.LogError("boom2");
+        }
+
+        inner.Records.Select(r => r.Message).Should().Equal("boom1", "after", "boom2");
+    }
+
+    /// <summary>
+    /// <see cref="LogLevel.None" /> is never written.
+    /// </summary>
+    [Fact]
+    public void NoneIsIgnored()
+    {
+        var logger = CreateLogger();
+
+        logger.Log(LogLevel.None, default, "x", null, (s, _) => s);
+
+        inner.Records.Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// A null formatter is rejected.
+    /// </summary>
+    [Fact]
+    public void LogNullFormatterThrows()
+    {
+        var logger = CreateLogger();
+
+        var act = () => logger.Log<string>(LogLevel.Information, default, "x", null, null!);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    /// <summary>
+    /// Buffered structured state is preserved on replay.
+    /// </summary>
+    [Fact]
+    public void BufferedStructuredStateIsPreservedOnReplay()
+    {
+        var logger = CreateLogger();
+
+        using (LogBuffer.BeginScope())
+        {
+            logger.LogDebug("order {OrderId}", 42);
+            logger.LogError("boom");
+        }
+
+        var replayed = inner.Records.First(r => r.Level == LogLevel.Debug);
+        replayed.State.Should().NotBeNull();
+        replayed.State!.Should().Contain(kv => kv.Key == "OrderId" && Equals(kv.Value, 42));
+    }
+
+    /// <summary>
+    /// <see cref="ILogger.IsEnabled" /> returns false for buffer-range levels when no scope is active.
+    /// </summary>
+    [Fact]
+    public void IsEnabledDebugFalseWithoutScope()
+    {
+        var logger = CreateLogger();
+
+        logger.IsEnabled(LogLevel.Debug).Should().BeFalse();
+    }
+
+    /// <summary>
+    /// <see cref="ILogger.IsEnabled" /> returns true for buffer-range levels inside an active scope.
+    /// </summary>
+    [Fact]
+    public void IsEnabledDebugTrueWithinScope()
+    {
+        var logger = CreateLogger();
+
+        using var scope = LogBuffer.BeginScope();
+
+        logger.IsEnabled(LogLevel.Debug).Should().BeTrue();
+    }
+
+    /// <summary>
+    /// <see cref="ILogger.IsEnabled" /> is false for <see cref="LogLevel.None" />.
+    /// </summary>
+    [Fact]
+    public void IsEnabledNoneFalse()
+    {
+        var logger = CreateLogger();
+
+        logger.IsEnabled(LogLevel.None).Should().BeFalse();
+    }
+
+    /// <summary>
+    /// Flush-level records are always enabled so the dump can be triggered, even if the inner logger
+    /// would filter them.
+    /// </summary>
+    [Fact]
+    public void IsEnabledErrorTrueEvenWhenInnerDisabled()
+    {
+        // An inner logger whose threshold is None is never enabled for any real level.
+        var quietInner = new RecordingLogger(LogLevel.None);
+        var logger = new BufferingLogger(quietInner, new BufferingLoggerOptions());
+
+        quietInner.IsEnabled(LogLevel.Error).Should().BeFalse();
+        logger.IsEnabled(LogLevel.Error).Should().BeTrue();
+    }
+
+    /// <summary>
+    /// <see cref="ILogger.BeginScope{TState}" /> is delegated to the inner logger.
+    /// </summary>
+    [Fact]
+    public void BeginScopeDelegatesToInner()
+    {
+        var logger = CreateLogger();
+
+        using var scope = logger.BeginScope("state");
+
+        scope.Should().NotBeNull();
+    }
+
+    /// <summary>
+    /// Concurrent buffer-range logging that shares a single ambient scope is thread-safe and never
+    /// throws, and the triggering error is always written.
+    /// </summary>
+    [Fact]
+    public void ConcurrentLoggingIsThreadSafe()
+    {
+        var logger = CreateLogger();
+
+        using (LogBuffer.BeginScope(256))
+        {
+            System.Threading.Tasks.Parallel.For(0, 1000, i => logger.LogDebug("n {N}", i));
+            logger.LogError("boom");
+        }
+
+        inner.Records.Should().Contain(r => r.Level == LogLevel.Error && r.Message == "boom");
+        // The ring buffer is bounded, so at most capacity debug records are dumped.
+        inner.Records.Count(r => r.Level == LogLevel.Debug).Should().BeLessThanOrEqualTo(256);
+    }
+
+    /// <summary>
+    /// An error with an empty buffer still suspends buffering for the rest of the scope, so a
+    /// subsequent buffer-range record is written live rather than re-buffered.
+    /// </summary>
+    [Fact]
+    public void EmptyErrorFlushSuspendsBuffering()
+    {
+        var logger = CreateLogger();
+
+        using var scope = LogBuffer.BeginScope();
+        logger.LogError("boom");
+        logger.LogDebug("after");
+
+        scope.IsFlushed.Should().BeTrue();
+        inner.Records.Select(r => r.Message).Should().Equal("boom", "after");
+    }
+
+    /// <summary>
+    /// A nested error dumps the whole live scope chain in chronological order (ancestors first), but
+    /// only suspends the innermost scope; ancestors are dumped for context yet keep buffering
+    /// afterward (they are not marked flushed), so records logged into the ancestor after the nested
+    /// error are still captured.
+    /// </summary>
+    [Fact]
+    public void NestedErrorDumpsChronologicallyAndLeavesAncestorBuffering()
+    {
+        var logger = CreateLogger();
+
+        using (var outer = LogBuffer.BeginScope())
+        {
+            logger.LogDebug("a1");
+
+            using (LogBuffer.BeginScope())
+            {
+                logger.LogDebug("b1");
+                logger.LogError("boom");
+            }
+
+            // The ancestor was dumped for context but not suspended.
+            outer.IsFlushed.Should().BeFalse();
+
+            logger.LogDebug("a2");
+            outer.Count.Should().Be(1);
+        }
+
+        // a2 is discarded when the outer scope disposes without its own error.
+        inner.Records.Select(r => r.Message).Should().Equal("a1", "b1", "boom");
+    }
+
+    /// <summary>
+    /// Object-valued structured properties are frozen to their log-time text, so mutating the source
+    /// object before the dump does not change what the replayed record reports.
+    /// </summary>
+    [Fact]
+    public void ObjectValuedStateIsFrozenAtLogTime()
+    {
+        var logger = CreateLogger();
+        var holder = new MutableValue { Text = "before" };
+
+        using (LogBuffer.BeginScope())
+        {
+            logger.LogDebug("state {Holder}", holder);
+            holder.Text = "after";
+            logger.LogError("boom");
+        }
+
+        var replayed = inner.Records.First(r => r.Level == LogLevel.Debug);
+        replayed.State!.Should().Contain(kv => kv.Key == "Holder" && Equals(kv.Value, "before"));
+    }
+
+    /// <summary>
+    /// A throwing <see cref="object.ToString" /> on a buffered value does not propagate into the
+    /// caller's logging path; the value is frozen to a fallback instead.
+    /// </summary>
+    [Fact]
+    public void ThrowingToStringOnBufferedValueDoesNotPropagate()
+    {
+        var logger = CreateLogger();
+
+        using var scope = LogBuffer.BeginScope();
+
+        var act = () => logger.LogDebug("bad {X}", new ThrowingToString());
+
+        act.Should().NotThrow();
+    }
+
+    /// <summary>
+    /// A faulty sink that throws while replaying one buffered record does not break the dump: the
+    /// remaining buffered records and the triggering error are still written.
+    /// </summary>
+    [Fact]
+    public void FaultyReplaySinkDoesNotBreakDump()
+    {
+        inner.ThrowOn = (level, message) => level == LogLevel.Debug && message == "a";
+        var logger = CreateLogger();
+
+        using (LogBuffer.BeginScope())
+        {
+            logger.LogDebug("a");
+            logger.LogDebug("b");
+            logger.LogError("boom");
+        }
+
+        inner.Records.Select(r => r.Message).Should().Equal("b", "boom");
+    }
+
+    /// <summary>
+    /// A structured state whose enumerator throws is snapshotted defensively: the buffer-path render
+    /// does not propagate, and the record is replayed with its rendered message.
+    /// </summary>
+    [Fact]
+    public void ThrowingStructuredStateDoesNotPropagate()
+    {
+        var logger = CreateLogger();
+
+        using (LogBuffer.BeginScope())
+        {
+            var act = () => logger.Log(
+                LogLevel.Debug,
+                default,
+                new ThrowingEnumerableState(),
+                null,
+                static (s, _) => s.ToString());
+
+            act.Should().NotThrow();
+
+            logger.LogError("boom");
+        }
+
+        inner.Records.Select(r => r.Message).Should().Equal("rendered", "boom");
+    }
+
+    private sealed class ThrowingEnumerableState : IReadOnlyList<KeyValuePair<string, object?>>
+    {
+        public int Count => throw new InvalidOperationException("nope");
+
+        public KeyValuePair<string, object?> this[int index] => throw new InvalidOperationException("nope");
+
+        public IEnumerator<KeyValuePair<string, object?>> GetEnumerator() =>
+            throw new InvalidOperationException("nope");
+
+        IEnumerator IEnumerable.GetEnumerator() => throw new InvalidOperationException("nope");
+
+        public override string ToString() => "rendered";
+    }
+
+    private sealed class MutableValue
+    {
+        public string Text { get; set; } = string.Empty;
+
+        public override string ToString() => Text;
+    }
+
+    private sealed class ThrowingToString
+    {
+        public override string ToString() => throw new InvalidOperationException("nope");
+    }
+}

--- a/src/JamesConsulting.Tests/Logging/BufferingLoggerTests.cs
+++ b/src/JamesConsulting.Tests/Logging/BufferingLoggerTests.cs
@@ -14,13 +14,25 @@ namespace JamesConsulting.Tests.Logging;
 /// </summary>
 public class BufferingLoggerTests
 {
-    private readonly RecordingLogger inner = new();
+    // The inner logger models the host's live configuration (Information threshold); the replay
+    // target models the direct provider replay that records every dumped record (Trace). Both append
+    // to one shared, ordered list, so assertions on `inner.Records` see live writes and dumped
+    // records interleaved in the exact order they reached the sinks.
+    private readonly List<RecordedLog> records = new();
+    private readonly RecordingLogger inner;
+    private readonly RecordingLogger replay;
+
+    public BufferingLoggerTests()
+    {
+        inner = new RecordingLogger(LogLevel.Information, records);
+        replay = new RecordingLogger(LogLevel.Trace, records);
+    }
 
     private BufferingLogger CreateLogger(Action<BufferingLoggerOptions>? configure = null)
     {
         var options = new BufferingLoggerOptions();
         configure?.Invoke(options);
-        return new BufferingLogger(inner, options);
+        return new BufferingLogger(inner, replay, options);
     }
 
     /// <summary>
@@ -29,7 +41,18 @@ public class BufferingLoggerTests
     [Fact]
     public void ConstructorNullInnerThrows()
     {
-        var act = () => new BufferingLogger(null!, new BufferingLoggerOptions());
+        var act = () => new BufferingLogger(null!, replay, new BufferingLoggerOptions());
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    /// <summary>
+    /// A null replay target is rejected.
+    /// </summary>
+    [Fact]
+    public void ConstructorNullReplayTargetThrows()
+    {
+        var act = () => new BufferingLogger(inner, null!, new BufferingLoggerOptions());
 
         act.Should().Throw<ArgumentNullException>();
     }
@@ -40,7 +63,7 @@ public class BufferingLoggerTests
     [Fact]
     public void ConstructorNullOptionsThrows()
     {
-        var act = () => new BufferingLogger(inner, null!);
+        var act = () => new BufferingLogger(inner, replay, null!);
 
         act.Should().Throw<ArgumentNullException>();
     }
@@ -53,13 +76,14 @@ public class BufferingLoggerTests
     {
         var options = new BufferingLoggerOptions { FlushLevel = LogLevel.None };
 
-        var act = () => new BufferingLogger(inner, options);
+        var act = () => new BufferingLogger(inner, replay, options);
 
         act.Should().Throw<ArgumentOutOfRangeException>();
     }
 
     /// <summary>
-    /// Passthrough-level records are written through immediately, even without a scope.
+    /// Records the host configuration already writes live (here Information) are written through
+    /// immediately, even without a scope.
     /// </summary>
     [Fact]
     public void InformationIsWrittenLive()
@@ -137,20 +161,23 @@ public class BufferingLoggerTests
     }
 
     /// <summary>
-    /// After a flush, buffer-range records are written live when suspend-after-flush is enabled.
+    /// After a flush, a buffer-range record the host configuration does not write live is dropped
+    /// (the host <c>LogLevel</c> stays authoritative once buffering is suspended), while a record the
+    /// host does write live still goes through.
     /// </summary>
     [Fact]
-    public void SuspendAfterFlushWritesSubsequentDebugLive()
+    public void SuspendAfterFlushDropsBelowLiveButWritesLive()
     {
         var logger = CreateLogger(o => o.SuspendBufferingAfterFlush = true);
 
         using (LogBuffer.BeginScope())
         {
             logger.LogError("boom");
-            logger.LogDebug("after");
+            logger.LogDebug("after");            // below the live threshold and buffering is suspended -> dropped
+            logger.LogInformation("after-info"); // at/above the live threshold -> written live
         }
 
-        inner.Records.Select(r => r.Message).Should().Equal("boom", "after");
+        inner.Records.Select(r => r.Message).Should().Equal("boom", "after-info");
     }
 
     /// <summary>
@@ -255,18 +282,27 @@ public class BufferingLoggerTests
     }
 
     /// <summary>
-    /// Flush-level records are always enabled so the dump can be triggered, even if the inner logger
-    /// would filter them.
+    /// Flush-level <see cref="ILogger.IsEnabled" /> reflects the host configuration when there is no
+    /// scope, but is forced true while a scope is active so the dump can always be triggered — even
+    /// if the inner logger would filter the level.
     /// </summary>
     [Fact]
-    public void IsEnabledErrorTrueEvenWhenInnerDisabled()
+    public void IsEnabledErrorReflectsScopeWhenInnerDisabled()
     {
         // An inner logger whose threshold is None is never enabled for any real level.
         var quietInner = new RecordingLogger(LogLevel.None);
-        var logger = new BufferingLogger(quietInner, new BufferingLoggerOptions());
+        var logger = new BufferingLogger(quietInner, replay, new BufferingLoggerOptions());
 
         quietInner.IsEnabled(LogLevel.Error).Should().BeFalse();
-        logger.IsEnabled(LogLevel.Error).Should().BeTrue();
+
+        // No scope: nothing to dump, so the host configuration is authoritative -> disabled.
+        logger.IsEnabled(LogLevel.Error).Should().BeFalse();
+
+        // Active scope: the record can trigger a dump, so it is enabled regardless of the host filter.
+        using (LogBuffer.BeginScope())
+        {
+            logger.IsEnabled(LogLevel.Error).Should().BeTrue();
+        }
     }
 
     /// <summary>
@@ -277,9 +313,13 @@ public class BufferingLoggerTests
     {
         var logger = CreateLogger();
 
+        // The inner RecordingLogger returns a shared sentinel from BeginScope; if the decorator
+        // delegates, it returns that same instance rather than a scope of its own.
+        var expected = inner.BeginScope("sentinel");
+
         using var scope = logger.BeginScope("state");
 
-        scope.Should().NotBeNull();
+        scope.Should().BeSameAs(expected);
     }
 
     /// <summary>
@@ -298,13 +338,15 @@ public class BufferingLoggerTests
         }
 
         inner.Records.Should().Contain(r => r.Level == LogLevel.Error && r.Message == "boom");
-        // The ring buffer is bounded, so at most capacity debug records are dumped.
-        inner.Records.Count(r => r.Level == LogLevel.Debug).Should().BeLessThanOrEqualTo(256);
+        // All 1000 debug records are enqueued (under lock) before the error triggers the dump, so the
+        // bounded ring buffer holds exactly its capacity and dumps that many — proving records were
+        // actually buffered and replayed, not silently lost.
+        inner.Records.Count(r => r.Level == LogLevel.Debug).Should().Be(256);
     }
 
     /// <summary>
     /// An error with an empty buffer still suspends buffering for the rest of the scope, so a
-    /// subsequent buffer-range record is written live rather than re-buffered.
+    /// subsequent buffer-range record below the live threshold is dropped rather than re-buffered.
     /// </summary>
     [Fact]
     public void EmptyErrorFlushSuspendsBuffering()
@@ -316,7 +358,7 @@ public class BufferingLoggerTests
         logger.LogDebug("after");
 
         scope.IsFlushed.Should().BeTrue();
-        inner.Records.Select(r => r.Message).Should().Equal("boom", "after");
+        inner.Records.Select(r => r.Message).Should().Equal("boom");
     }
 
     /// <summary>
@@ -395,7 +437,7 @@ public class BufferingLoggerTests
     [Fact]
     public void FaultyReplaySinkDoesNotBreakDump()
     {
-        inner.ThrowOn = (level, message) => level == LogLevel.Debug && message == "a";
+        replay.ThrowOn = (level, message) => level == LogLevel.Debug && message == "a";
         var logger = CreateLogger();
 
         using (LogBuffer.BeginScope())
@@ -432,6 +474,46 @@ public class BufferingLoggerTests
         }
 
         inner.Records.Select(r => r.Message).Should().Equal("rendered", "boom");
+    }
+
+    /// <summary>
+    /// With no active scope, a flush-level record honors the host configuration exactly: an inner
+    /// logger that suppresses the level (the host <c>LogLevel</c> stays authoritative) drops it, since
+    /// there is no buffered context to dump.
+    /// </summary>
+    [Fact]
+    public void NoScopeFlushLevelHonorsHostFilterWhenSuppressed()
+    {
+        var shared = new List<RecordedLog>();
+        var quietInner = new RecordingLogger(LogLevel.Critical, shared);
+        var quietReplay = new RecordingLogger(LogLevel.Trace, shared);
+        var logger = new BufferingLogger(quietInner, quietReplay, new BufferingLoggerOptions());
+
+        logger.LogError("boom");
+
+        shared.Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// With an active scope, an error dumps the buffered context and the triggering record directly
+    /// to the replay target, bypassing the host filter — so suppressed low-level context and the
+    /// error both surface even when the inner logger would filter every one of them.
+    /// </summary>
+    [Fact]
+    public void ScopedErrorDumpsViaReplayBypassingHostFilter()
+    {
+        var shared = new List<RecordedLog>();
+        var quietInner = new RecordingLogger(LogLevel.Critical, shared);
+        var quietReplay = new RecordingLogger(LogLevel.Trace, shared);
+        var logger = new BufferingLogger(quietInner, quietReplay, new BufferingLoggerOptions());
+
+        using (LogBuffer.BeginScope())
+        {
+            logger.LogDebug("ctx");
+            logger.LogError("boom");
+        }
+
+        shared.Select(r => r.Message).Should().Equal("ctx", "boom");
     }
 
     private sealed class ThrowingEnumerableState : IReadOnlyList<KeyValuePair<string, object?>>

--- a/src/JamesConsulting.Tests/Logging/BufferingLoggingServiceCollectionExtensionsTests.cs
+++ b/src/JamesConsulting.Tests/Logging/BufferingLoggingServiceCollectionExtensionsTests.cs
@@ -1,0 +1,414 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using JamesConsulting.Logging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace JamesConsulting.Tests.Logging;
+
+/// <summary>
+/// Integration tests for the <c>AddBufferingLogging</c> DI extensions, verifying that the registered
+/// <see cref="ILoggerFactory" /> is decorated and that <see cref="ILogger{T}" /> resolves to a
+/// buffering logger end to end.
+/// </summary>
+public class BufferingLoggingServiceCollectionExtensionsTests
+{
+    /// <summary>
+    /// A null service collection is rejected.
+    /// </summary>
+    [Fact]
+    public void AddBufferingLoggingNullServicesThrows()
+    {
+        IServiceCollection services = null!;
+
+        var act = () => services.AddBufferingLogging();
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    /// <summary>
+    /// A null logging builder is rejected.
+    /// </summary>
+    [Fact]
+    public void AddBufferingLoggingNullBuilderThrows()
+    {
+        ILoggingBuilder builder = null!;
+
+        var act = () => builder.AddBufferingLogging();
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    /// <summary>
+    /// The builder overload returns the same builder for chaining.
+    /// </summary>
+    [Fact]
+    public void AddBufferingLoggingBuilderReturnsSameBuilder()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging(builder =>
+        {
+            var result = builder.AddBufferingLogging();
+            result.Should().BeSameAs(builder);
+        });
+
+        using var provider = services.BuildServiceProvider();
+        provider.GetRequiredService<ILoggerFactory>().Should().BeOfType<BufferingLoggerFactory>();
+    }
+
+    /// <summary>
+    /// Calling the extension before logging is registered throws a helpful error.
+    /// </summary>
+    [Fact]
+    public void AddBufferingLoggingWithoutLoggingThrows()
+    {
+        var services = new ServiceCollection();
+
+        var act = () => services.AddBufferingLogging();
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*AddLogging*");
+    }
+
+    /// <summary>
+    /// Invalid options surface as an argument-out-of-range during registration.
+    /// </summary>
+    [Fact]
+    public void AddBufferingLoggingInvalidOptionsThrows()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        var act = () => services.AddBufferingLogging(o => o.FlushLevel = LogLevel.None);
+
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    /// <summary>
+    /// The resolved <see cref="ILoggerFactory" /> is the buffering decorator.
+    /// </summary>
+    [Fact]
+    public void AddBufferingLoggingDecoratesFactory()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddBufferingLogging();
+
+        using var provider = services.BuildServiceProvider();
+        var factory = provider.GetRequiredService<ILoggerFactory>();
+
+        factory.Should().BeOfType<BufferingLoggerFactory>();
+    }
+
+    /// <summary>
+    /// End to end: a resolved <see cref="ILogger{T}" /> buffers Debug logs and dumps them when an
+    /// error is logged within a scope.
+    /// </summary>
+    [Fact]
+    public void ResolvedLoggerDumpsOnErrorWithinScope()
+    {
+        var recorder = new RecordingProvider();
+        var services = new ServiceCollection();
+        services.AddLogging(builder =>
+        {
+            builder.SetMinimumLevel(LogLevel.Trace);
+            builder.AddProvider(recorder);
+            builder.AddBufferingLogging();
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var logger = provider.GetRequiredService<ILogger<BufferingLoggingServiceCollectionExtensionsTests>>();
+
+        using (LogBuffer.BeginScope())
+        {
+            logger.LogDebug("step one");
+            logger.LogDebug("step two");
+            logger.LogError("failure");
+        }
+
+        recorder.Messages.Should().ContainInOrder("step one", "step two", "failure");
+    }
+
+    /// <summary>
+    /// End to end: Debug logs are suppressed when no error occurs.
+    /// </summary>
+    [Fact]
+    public void ResolvedLoggerSuppressesDebugWithoutError()
+    {
+        var recorder = new RecordingProvider();
+        var services = new ServiceCollection();
+        services.AddLogging(builder =>
+        {
+            builder.SetMinimumLevel(LogLevel.Trace);
+            builder.AddProvider(recorder);
+            builder.AddBufferingLogging();
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var logger = provider.GetRequiredService<ILogger<BufferingLoggingServiceCollectionExtensionsTests>>();
+
+        using (LogBuffer.BeginScope())
+        {
+            logger.LogDebug("hidden");
+            logger.LogInformation("shown");
+        }
+
+        recorder.Messages.Should().Contain("shown");
+        recorder.Messages.Should().NotContain("hidden");
+    }
+
+    /// <summary>
+    /// Calling the extension twice is idempotent: it does not nest decorators or duplicate the dump.
+    /// </summary>
+    [Fact]
+    public void AddBufferingLoggingIsIdempotent()
+    {
+        var recorder = new RecordingProvider();
+        var services = new ServiceCollection();
+        services.AddLogging(builder =>
+        {
+            builder.SetMinimumLevel(LogLevel.Trace);
+            builder.AddProvider(recorder);
+            builder.AddBufferingLogging();
+            builder.AddBufferingLogging();
+        });
+
+        using var provider = services.BuildServiceProvider();
+        provider.GetRequiredService<ILoggerFactory>().Should().BeOfType<BufferingLoggerFactory>();
+
+        var logger = provider.GetRequiredService<ILogger<BufferingLoggingServiceCollectionExtensionsTests>>();
+        using (LogBuffer.BeginScope())
+        {
+            logger.LogDebug("ctx");
+            logger.LogError("boom");
+        }
+
+        recorder.Messages.Count(m => m == "ctx").Should().Be(1);
+        recorder.Messages.Count(m => m == "boom").Should().Be(1);
+    }
+
+    /// <summary>
+    /// With <see cref="BufferingLoggerOptions.ConfigureUnderlyingFilter" /> enabled (the default), the
+    /// auto-appended buffer-level rule wins over a configuration-bound <c>Default</c> rule, so a
+    /// dumped Debug record still reaches the provider without any manual filter setup.
+    /// </summary>
+    [Fact]
+    public void ConfigureUnderlyingFilterLetsDumpBeatConfiguredDefault()
+    {
+        var recorder = new RecordingProvider();
+        var services = new ServiceCollection();
+        services.AddLogging(builder =>
+        {
+            builder.AddProvider(recorder);
+            builder.AddBufferingLogging();
+        });
+
+        // Simulate a configuration-bound Logging:LogLevel:Default = Information rule. A Configure
+        // callback runs before the extension's PostConfigure, so our buffer-level rule is appended
+        // last and wins the tie-break.
+        services.Configure<LoggerFilterOptions>(o =>
+            o.Rules.Add(new LoggerFilterRule(null, null, LogLevel.Information, null)));
+
+        using var provider = services.BuildServiceProvider();
+        var logger = provider.GetRequiredService<ILogger<BufferingLoggingServiceCollectionExtensionsTests>>();
+
+        using (LogBuffer.BeginScope())
+        {
+            logger.LogDebug("ctx");
+            logger.LogError("boom");
+        }
+
+        recorder.Messages.Should().ContainInOrder("ctx", "boom");
+    }
+
+    /// <summary>
+    /// With <see cref="BufferingLoggerOptions.ConfigureUnderlyingFilter" /> disabled and an inner
+    /// filter that excludes the buffer level, the dump is filtered out but the triggering error is
+    /// still written and the logger warns exactly once about the misconfiguration.
+    /// </summary>
+    [Fact]
+    public void DisablingConfigureUnderlyingFilterFiltersDumpAndWarnsOnce()
+    {
+        var recorder = new RecordingProvider();
+        var services = new ServiceCollection();
+        services.AddLogging(builder =>
+        {
+            builder.SetMinimumLevel(LogLevel.Information);
+            builder.AddProvider(recorder);
+            builder.AddBufferingLogging(o => o.ConfigureUnderlyingFilter = false);
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var logger = provider.GetRequiredService<ILogger<BufferingLoggingServiceCollectionExtensionsTests>>();
+
+        using (LogBuffer.BeginScope())
+        {
+            logger.LogDebug("ctx1");
+            logger.LogError("boom1");
+        }
+
+        using (LogBuffer.BeginScope())
+        {
+            logger.LogDebug("ctx2");
+            logger.LogError("boom2");
+        }
+
+        recorder.Messages.Should().NotContain("ctx1");
+        recorder.Messages.Should().NotContain("ctx2");
+        recorder.Messages.Should().Contain("boom1");
+        recorder.Messages.Should().Contain("boom2");
+        recorder.Messages.Count(m => m.Contains("are filtered out by the underlying logging configuration")).Should().Be(1);
+    }
+
+    /// <summary>
+    /// The dump-filtered backstop warning only fires when a buffering scope is active. A bare
+    /// flush-level record outside any scope dumps nothing, so it must not raise the warning or burn
+    /// the once-only guard that a later real dump relies on.
+    /// </summary>
+    [Fact]
+    public void DumpFilteredWarningDoesNotFireWithoutActiveScope()
+    {
+        var recorder = new RecordingProvider();
+        var services = new ServiceCollection();
+        services.AddLogging(builder =>
+        {
+            builder.SetMinimumLevel(LogLevel.Information);
+            builder.AddProvider(recorder);
+            builder.AddBufferingLogging(o => o.ConfigureUnderlyingFilter = false);
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var logger = provider.GetRequiredService<ILogger<BufferingLoggingServiceCollectionExtensionsTests>>();
+
+        // No LogBuffer scope: nothing is buffered, so the error dumps nothing.
+        logger.LogError("boom-no-scope");
+
+        recorder.Messages.Should().Contain("boom-no-scope");
+        recorder.Messages.Should().NotContain(m => m.Contains("are filtered out by the underlying logging configuration"));
+
+        // The guard was not consumed, so a subsequent real scoped dump still warns.
+        using (LogBuffer.BeginScope())
+        {
+            logger.LogDebug("ctx");
+            logger.LogError("boom");
+        }
+
+        recorder.Messages.Count(m => m.Contains("are filtered out by the underlying logging configuration")).Should().Be(1);
+    }
+
+    /// <summary>
+    /// The auto-appended no-category rule does not override a more specific category rule, so a
+    /// category that is filtered above the buffer level still loses its dump — and the logger warns
+    /// once about it. This locks in the documented limitation.
+    /// </summary>
+    [Fact]
+    public void ConfigureUnderlyingFilterDoesNotBeatCategoryRuleAndWarnsOnce()
+    {
+        var recorder = new RecordingProvider();
+        var services = new ServiceCollection();
+        var category = typeof(BufferingLoggingServiceCollectionExtensionsTests).FullName!;
+        services.AddLogging(builder =>
+        {
+            builder.AddProvider(recorder);
+            builder.AddBufferingLogging();
+        });
+
+        // A category-specific rule at Information is more specific than our null/null buffer rule.
+        services.Configure<LoggerFilterOptions>(o =>
+            o.Rules.Add(new LoggerFilterRule(null, category, LogLevel.Information, null)));
+
+        using var provider = services.BuildServiceProvider();
+        var logger = provider.GetRequiredService<ILogger<BufferingLoggingServiceCollectionExtensionsTests>>();
+
+        using (LogBuffer.BeginScope())
+        {
+            logger.LogDebug("ctx1");
+            logger.LogError("boom1");
+        }
+
+        using (LogBuffer.BeginScope())
+        {
+            logger.LogDebug("ctx2");
+            logger.LogError("boom2");
+        }
+
+        recorder.Messages.Should().NotContain("ctx1");
+        recorder.Messages.Should().NotContain("ctx2");
+        recorder.Messages.Should().Contain("boom1");
+        recorder.Messages.Count(m => m.Contains("are filtered out by the underlying logging configuration")).Should().Be(1);
+    }
+
+    /// <summary>
+    /// When the underlying filter is higher than Warning, the backstop "dump filtered" warning is
+    /// still visible because it is emitted at the flush level (which is written live).
+    /// </summary>
+    [Fact]
+    public void DumpFilteredWarningIsVisibleAboveWarningThreshold()
+    {
+        var recorder = new RecordingProvider();
+        var services = new ServiceCollection();
+        services.AddLogging(builder =>
+        {
+            builder.SetMinimumLevel(LogLevel.Error);
+            builder.AddProvider(recorder);
+            builder.AddBufferingLogging(o => o.ConfigureUnderlyingFilter = false);
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var logger = provider.GetRequiredService<ILogger<BufferingLoggingServiceCollectionExtensionsTests>>();
+
+        using (LogBuffer.BeginScope())
+        {
+            logger.LogDebug("ctx");
+            logger.LogError("boom");
+        }
+
+        recorder.Messages.Should().NotContain("ctx");
+        recorder.Messages.Should().Contain("boom");
+        recorder.Messages.Count(m => m.Contains("are filtered out by the underlying logging configuration")).Should().Be(1);
+    }
+
+    private sealed class RecordingProvider : ILoggerProvider
+    {
+        public ConcurrentQueue<string> Messages { get; } = new();
+
+        public ILogger CreateLogger(string categoryName) => new ProviderLogger(Messages);
+
+        public void Dispose()
+        {
+        }
+
+        private sealed class ProviderLogger : ILogger
+        {
+            private readonly ConcurrentQueue<string> messages;
+
+            public ProviderLogger(ConcurrentQueue<string> messages) => this.messages = messages;
+
+            public IDisposable BeginScope<TState>(TState state)
+                where TState : notnull => NullScope.Instance;
+
+            public bool IsEnabled(LogLevel logLevel) => true;
+
+            public void Log<TState>(
+                LogLevel logLevel,
+                EventId eventId,
+                TState state,
+                Exception? exception,
+                Func<TState, Exception?, string> formatter) =>
+                messages.Enqueue(formatter(state, exception));
+
+            private sealed class NullScope : IDisposable
+            {
+                public static readonly NullScope Instance = new();
+
+                public void Dispose()
+                {
+                }
+            }
+        }
+    }
+}

--- a/src/JamesConsulting.Tests/Logging/BufferingLoggingServiceCollectionExtensionsTests.cs
+++ b/src/JamesConsulting.Tests/Logging/BufferingLoggingServiceCollectionExtensionsTests.cs
@@ -105,8 +105,9 @@ public class BufferingLoggingServiceCollectionExtensionsTests
     }
 
     /// <summary>
-    /// End to end: a resolved <see cref="ILogger{T}" /> buffers Debug logs and dumps them when an
-    /// error is logged within a scope.
+    /// End to end: a resolved <see cref="ILogger{T}" /> buffers Debug logs (which the host's
+    /// Information live threshold suppresses) and dumps them directly to the provider when an error is
+    /// logged within a scope.
     /// </summary>
     [Fact]
     public void ResolvedLoggerDumpsOnErrorWithinScope()
@@ -115,7 +116,7 @@ public class BufferingLoggingServiceCollectionExtensionsTests
         var services = new ServiceCollection();
         services.AddLogging(builder =>
         {
-            builder.SetMinimumLevel(LogLevel.Trace);
+            builder.SetMinimumLevel(LogLevel.Information);
             builder.AddProvider(recorder);
             builder.AddBufferingLogging();
         });
@@ -143,7 +144,7 @@ public class BufferingLoggingServiceCollectionExtensionsTests
         var services = new ServiceCollection();
         services.AddLogging(builder =>
         {
-            builder.SetMinimumLevel(LogLevel.Trace);
+            builder.SetMinimumLevel(LogLevel.Information);
             builder.AddProvider(recorder);
             builder.AddBufferingLogging();
         });
@@ -171,7 +172,7 @@ public class BufferingLoggingServiceCollectionExtensionsTests
         var services = new ServiceCollection();
         services.AddLogging(builder =>
         {
-            builder.SetMinimumLevel(LogLevel.Trace);
+            builder.SetMinimumLevel(LogLevel.Information);
             builder.AddProvider(recorder);
             builder.AddBufferingLogging();
             builder.AddBufferingLogging();
@@ -192,12 +193,31 @@ public class BufferingLoggingServiceCollectionExtensionsTests
     }
 
     /// <summary>
-    /// With <see cref="BufferingLoggerOptions.ConfigureUnderlyingFilter" /> enabled (the default), the
-    /// auto-appended buffer-level rule wins over a configuration-bound <c>Default</c> rule, so a
-    /// dumped Debug record still reaches the provider without any manual filter setup.
+    /// Idempotency is decided before options are configured or validated, so a second call with
+    /// invalid options is ignored (the first registration wins) rather than throwing.
     /// </summary>
     [Fact]
-    public void ConfigureUnderlyingFilterLetsDumpBeatConfiguredDefault()
+    public void AddBufferingLoggingSecondInvalidCallIsIgnored()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddBufferingLogging();
+
+        var act = () => services.AddBufferingLogging(o => o.FlushLevel = LogLevel.None);
+
+        act.Should().NotThrow();
+        using var provider = services.BuildServiceProvider();
+        provider.GetRequiredService<ILoggerFactory>().Should().BeOfType<BufferingLoggerFactory>();
+    }
+
+    /// <summary>
+    /// The error dump is written directly to the registered providers, so it bypasses the
+    /// Microsoft.Extensions.Logging factory-level filters: a configuration-bound <c>Default</c> rule
+    /// at Information suppresses Debug live, yet the buffered Debug context still surfaces on error —
+    /// exactly once (the dump), with no live duplicate, and without any extra filter configuration.
+    /// </summary>
+    [Fact]
+    public void DumpBypassesConfiguredFactoryFilter()
     {
         var recorder = new RecordingProvider();
         var services = new ServiceCollection();
@@ -207,9 +227,6 @@ public class BufferingLoggingServiceCollectionExtensionsTests
             builder.AddBufferingLogging();
         });
 
-        // Simulate a configuration-bound Logging:LogLevel:Default = Information rule. A Configure
-        // callback runs before the extension's PostConfigure, so our buffer-level rule is appended
-        // last and wins the tie-break.
         services.Configure<LoggerFilterOptions>(o =>
             o.Rules.Add(new LoggerFilterRule(null, null, LogLevel.Information, null)));
 
@@ -223,153 +240,47 @@ public class BufferingLoggingServiceCollectionExtensionsTests
         }
 
         recorder.Messages.Should().ContainInOrder("ctx", "boom");
+        recorder.Messages.Count(m => m == "ctx").Should().Be(1);
+        recorder.Messages.Count(m => m == "boom").Should().Be(1);
     }
 
     /// <summary>
-    /// With <see cref="BufferingLoggerOptions.ConfigureUnderlyingFilter" /> disabled and an inner
-    /// filter that excludes the buffer level, the dump is filtered out but the triggering error is
-    /// still written and the logger warns exactly once about the misconfiguration.
+    /// The host's live <c>LogLevel</c> stays authoritative (no override): a flush-level record with no
+    /// active scope follows the configured filter exactly, so an error below a configured <c>Default</c>
+    /// rule is suppressed. Inside a scope, the same error dumps the buffered context directly to the
+    /// provider, bypassing that filter.
     /// </summary>
     [Fact]
-    public void DisablingConfigureUnderlyingFilterFiltersDumpAndWarnsOnce()
+    public void NoScopeErrorHonorsHostFilterButScopedErrorDumps()
     {
         var recorder = new RecordingProvider();
         var services = new ServiceCollection();
-        services.AddLogging(builder =>
-        {
-            builder.SetMinimumLevel(LogLevel.Information);
-            builder.AddProvider(recorder);
-            builder.AddBufferingLogging(o => o.ConfigureUnderlyingFilter = false);
-        });
-
-        using var provider = services.BuildServiceProvider();
-        var logger = provider.GetRequiredService<ILogger<BufferingLoggingServiceCollectionExtensionsTests>>();
-
-        using (LogBuffer.BeginScope())
-        {
-            logger.LogDebug("ctx1");
-            logger.LogError("boom1");
-        }
-
-        using (LogBuffer.BeginScope())
-        {
-            logger.LogDebug("ctx2");
-            logger.LogError("boom2");
-        }
-
-        recorder.Messages.Should().NotContain("ctx1");
-        recorder.Messages.Should().NotContain("ctx2");
-        recorder.Messages.Should().Contain("boom1");
-        recorder.Messages.Should().Contain("boom2");
-        recorder.Messages.Count(m => m.Contains("are filtered out by the underlying logging configuration")).Should().Be(1);
-    }
-
-    /// <summary>
-    /// The dump-filtered backstop warning only fires when a buffering scope is active. A bare
-    /// flush-level record outside any scope dumps nothing, so it must not raise the warning or burn
-    /// the once-only guard that a later real dump relies on.
-    /// </summary>
-    [Fact]
-    public void DumpFilteredWarningDoesNotFireWithoutActiveScope()
-    {
-        var recorder = new RecordingProvider();
-        var services = new ServiceCollection();
-        services.AddLogging(builder =>
-        {
-            builder.SetMinimumLevel(LogLevel.Information);
-            builder.AddProvider(recorder);
-            builder.AddBufferingLogging(o => o.ConfigureUnderlyingFilter = false);
-        });
-
-        using var provider = services.BuildServiceProvider();
-        var logger = provider.GetRequiredService<ILogger<BufferingLoggingServiceCollectionExtensionsTests>>();
-
-        // No LogBuffer scope: nothing is buffered, so the error dumps nothing.
-        logger.LogError("boom-no-scope");
-
-        recorder.Messages.Should().Contain("boom-no-scope");
-        recorder.Messages.Should().NotContain(m => m.Contains("are filtered out by the underlying logging configuration"));
-
-        // The guard was not consumed, so a subsequent real scoped dump still warns.
-        using (LogBuffer.BeginScope())
-        {
-            logger.LogDebug("ctx");
-            logger.LogError("boom");
-        }
-
-        recorder.Messages.Count(m => m.Contains("are filtered out by the underlying logging configuration")).Should().Be(1);
-    }
-
-    /// <summary>
-    /// The auto-appended no-category rule does not override a more specific category rule, so a
-    /// category that is filtered above the buffer level still loses its dump — and the logger warns
-    /// once about it. This locks in the documented limitation.
-    /// </summary>
-    [Fact]
-    public void ConfigureUnderlyingFilterDoesNotBeatCategoryRuleAndWarnsOnce()
-    {
-        var recorder = new RecordingProvider();
-        var services = new ServiceCollection();
-        var category = typeof(BufferingLoggingServiceCollectionExtensionsTests).FullName!;
         services.AddLogging(builder =>
         {
             builder.AddProvider(recorder);
             builder.AddBufferingLogging();
         });
 
-        // A category-specific rule at Information is more specific than our null/null buffer rule.
+        // A configured Default rule at Critical suppresses Error live.
         services.Configure<LoggerFilterOptions>(o =>
-            o.Rules.Add(new LoggerFilterRule(null, category, LogLevel.Information, null)));
+            o.Rules.Add(new LoggerFilterRule(null, null, LogLevel.Critical, null)));
 
         using var provider = services.BuildServiceProvider();
         var logger = provider.GetRequiredService<ILogger<BufferingLoggingServiceCollectionExtensionsTests>>();
 
-        using (LogBuffer.BeginScope())
-        {
-            logger.LogDebug("ctx1");
-            logger.LogError("boom1");
-        }
+        // No scope: nothing to dump, so the host filter is authoritative and the error is suppressed.
+        logger.LogError("boom-no-scope");
+        recorder.Messages.Should().NotContain("boom-no-scope");
 
-        using (LogBuffer.BeginScope())
-        {
-            logger.LogDebug("ctx2");
-            logger.LogError("boom2");
-        }
-
-        recorder.Messages.Should().NotContain("ctx1");
-        recorder.Messages.Should().NotContain("ctx2");
-        recorder.Messages.Should().Contain("boom1");
-        recorder.Messages.Count(m => m.Contains("are filtered out by the underlying logging configuration")).Should().Be(1);
-    }
-
-    /// <summary>
-    /// When the underlying filter is higher than Warning, the backstop "dump filtered" warning is
-    /// still visible because it is emitted at the flush level (which is written live).
-    /// </summary>
-    [Fact]
-    public void DumpFilteredWarningIsVisibleAboveWarningThreshold()
-    {
-        var recorder = new RecordingProvider();
-        var services = new ServiceCollection();
-        services.AddLogging(builder =>
-        {
-            builder.SetMinimumLevel(LogLevel.Error);
-            builder.AddProvider(recorder);
-            builder.AddBufferingLogging(o => o.ConfigureUnderlyingFilter = false);
-        });
-
-        using var provider = services.BuildServiceProvider();
-        var logger = provider.GetRequiredService<ILogger<BufferingLoggingServiceCollectionExtensionsTests>>();
-
+        // Active scope: the buffered context and the triggering error are replayed directly to the
+        // provider, bypassing the configured filter.
         using (LogBuffer.BeginScope())
         {
             logger.LogDebug("ctx");
             logger.LogError("boom");
         }
 
-        recorder.Messages.Should().NotContain("ctx");
-        recorder.Messages.Should().Contain("boom");
-        recorder.Messages.Count(m => m.Contains("are filtered out by the underlying logging configuration")).Should().Be(1);
+        recorder.Messages.Should().ContainInOrder("ctx", "boom");
     }
 
     private sealed class RecordingProvider : ILoggerProvider

--- a/src/JamesConsulting.Tests/Logging/LogBufferScopeTests.cs
+++ b/src/JamesConsulting.Tests/Logging/LogBufferScopeTests.cs
@@ -12,10 +12,19 @@ namespace JamesConsulting.Tests.Logging;
 /// </summary>
 public class LogBufferScopeTests
 {
-    private readonly RecordingLogger inner = new();
+    private readonly RecordingLogger inner;
     private readonly BufferingLogger logger;
 
-    public LogBufferScopeTests() => logger = new BufferingLogger(inner, new BufferingLoggerOptions());
+    public LogBufferScopeTests()
+    {
+        // Inner models the host live threshold (Information) so Debug/Trace are buffered rather than
+        // written live; the replay target records the dump. Both share one ordered list, so
+        // `inner.Records` observes exactly what reached the sinks, in order.
+        var records = new System.Collections.Generic.List<RecordedLog>();
+        inner = new RecordingLogger(LogLevel.Information, records);
+        var replay = new RecordingLogger(LogLevel.Trace, records);
+        logger = new BufferingLogger(inner, replay, new BufferingLoggerOptions());
+    }
 
     /// <summary>
     /// <see cref="LogBuffer.BeginScope()" /> uses the default capacity and becomes the current scope.
@@ -142,6 +151,42 @@ public class LogBufferScopeTests
         }
 
         LogBuffer.Current.Should().BeSameAs(outer);
+    }
+
+    /// <summary>
+    /// Disposing scopes out of order never leaves <see cref="LogBuffer.Current" /> pointing at a
+    /// disposed scope: when the inner scope is disposed after its already-disposed parent, the
+    /// ambient slot skips the disposed parent and restores the next live ancestor (here, none).
+    /// </summary>
+    [Fact]
+    public void OutOfOrderDisposalSkipsDisposedAncestor()
+    {
+        var outer = LogBuffer.BeginScope();
+        var innerScope = LogBuffer.BeginScope();
+
+        outer.Dispose();
+        LogBuffer.Current.Should().BeSameAs(innerScope);
+
+        innerScope.Dispose();
+        LogBuffer.Current.Should().BeNull();
+    }
+
+    /// <summary>
+    /// With three nested scopes, disposing the middle one out of order makes the innermost restore
+    /// the live grandparent (skipping the disposed middle scope) rather than a disposed scope.
+    /// </summary>
+    [Fact]
+    public void OutOfOrderDisposalRestoresNearestLiveAncestor()
+    {
+        using var root = LogBuffer.BeginScope();
+        var middle = LogBuffer.BeginScope();
+        var innermost = LogBuffer.BeginScope();
+
+        middle.Dispose();
+        LogBuffer.Current.Should().BeSameAs(innermost);
+
+        innermost.Dispose();
+        LogBuffer.Current.Should().BeSameAs(root);
     }
 
     /// <summary>

--- a/src/JamesConsulting.Tests/Logging/LogBufferScopeTests.cs
+++ b/src/JamesConsulting.Tests/Logging/LogBufferScopeTests.cs
@@ -1,0 +1,220 @@
+﻿using System.Linq;
+using FluentAssertions;
+using JamesConsulting.Logging;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace JamesConsulting.Tests.Logging;
+
+/// <summary>
+/// Unit tests for <see cref="LogBufferScope" /> lifecycle and <see cref="LogBuffer" /> ambient
+/// scope management, driven through the public buffering API.
+/// </summary>
+public class LogBufferScopeTests
+{
+    private readonly RecordingLogger inner = new();
+    private readonly BufferingLogger logger;
+
+    public LogBufferScopeTests() => logger = new BufferingLogger(inner, new BufferingLoggerOptions());
+
+    /// <summary>
+    /// <see cref="LogBuffer.BeginScope()" /> uses the default capacity and becomes the current scope.
+    /// </summary>
+    [Fact]
+    public void BeginScopeSetsCurrentWithDefaultCapacity()
+    {
+        using var scope = LogBuffer.BeginScope();
+
+        LogBuffer.Current.Should().BeSameAs(scope);
+        scope.Capacity.Should().Be(LogBufferScope.DefaultCapacity);
+        scope.Count.Should().Be(0);
+        scope.IsFlushed.Should().BeFalse();
+        scope.IsDisposed.Should().BeFalse();
+    }
+
+    /// <summary>
+    /// Disposing the scope clears the ambient slot and marks the scope disposed.
+    /// </summary>
+    [Fact]
+    public void DisposeClearsCurrent()
+    {
+        var scope = LogBuffer.BeginScope();
+        scope.Dispose();
+
+        LogBuffer.Current.Should().BeNull();
+        scope.IsDisposed.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// The ring buffer drops the oldest records once capacity is exceeded.
+    /// </summary>
+    [Fact]
+    public void OverflowDropsOldest()
+    {
+        using (LogBuffer.BeginScope(2))
+        {
+            logger.LogDebug("one");
+            logger.LogDebug("two");
+            logger.LogDebug("three");
+            logger.LogError("boom");
+        }
+
+        inner.Records.Where(r => r.Level == LogLevel.Debug).Select(r => r.Message)
+            .Should().Equal("two", "three");
+    }
+
+    /// <summary>
+    /// Disposing without flushing discards the buffered records.
+    /// </summary>
+    [Fact]
+    public void DisposeWithoutFlushDiscardsBuffer()
+    {
+        using (LogBuffer.BeginScope())
+        {
+            logger.LogDebug("debug");
+        }
+
+        inner.Records.Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// A manual <see cref="LogBufferScope.Flush" /> dumps buffered records in order and marks the
+    /// scope flushed.
+    /// </summary>
+    [Fact]
+    public void ManualFlushDumpsInOrder()
+    {
+        using var scope = LogBuffer.BeginScope();
+        logger.LogDebug("a");
+        logger.LogDebug("b");
+
+        scope.Flush();
+
+        inner.Records.Select(r => r.Message).Should().Equal("a", "b");
+        scope.IsFlushed.Should().BeTrue();
+        scope.Count.Should().Be(0);
+    }
+
+    /// <summary>
+    /// Flushing twice is safe and does not re-emit records.
+    /// </summary>
+    [Fact]
+    public void FlushIsIdempotent()
+    {
+        using var scope = LogBuffer.BeginScope();
+        logger.LogDebug("a");
+
+        scope.Flush();
+        scope.Flush();
+
+        inner.Records.Should().ContainSingle();
+    }
+
+    /// <summary>
+    /// A manual <see cref="LogBufferScope.Flush" /> on an empty buffer is a no-op and does not
+    /// suspend buffering, so subsequent buffer-range records are still captured.
+    /// </summary>
+    [Fact]
+    public void EmptyManualFlushDoesNotSuspendBuffering()
+    {
+        using var scope = LogBuffer.BeginScope();
+
+        scope.Flush();
+
+        scope.IsFlushed.Should().BeFalse();
+
+        logger.LogDebug("after");
+
+        scope.Count.Should().Be(1);
+        inner.Records.Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// Nested scopes restore their parent on disposal.
+    /// </summary>
+    [Fact]
+    public void NestedScopesRestoreParent()
+    {
+        using var outer = LogBuffer.BeginScope();
+        using (var innerScope = LogBuffer.BeginScope())
+        {
+            LogBuffer.Current.Should().BeSameAs(innerScope);
+        }
+
+        LogBuffer.Current.Should().BeSameAs(outer);
+    }
+
+    /// <summary>
+    /// Records buffered in a nested scope are independent of the parent scope.
+    /// </summary>
+    [Fact]
+    public void NestedScopeBuffersIndependently()
+    {
+        using var outer = LogBuffer.BeginScope();
+        logger.LogDebug("outer");
+
+        using (LogBuffer.BeginScope())
+        {
+            logger.LogDebug("inner");
+            outer.Count.Should().Be(1);
+            LogBuffer.Current!.Count.Should().Be(1);
+        }
+    }
+
+    /// <summary>
+    /// A non-positive capacity is rejected.
+    /// </summary>
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void BeginScopeRejectsNonPositiveCapacity(int capacity)
+    {
+        var act = () => LogBuffer.BeginScope(capacity);
+
+        act.Should().Throw<System.ArgumentOutOfRangeException>();
+    }
+
+    /// <summary>
+    /// Disposing a scope twice is safe.
+    /// </summary>
+    [Fact]
+    public void DoubleDisposeIsSafe()
+    {
+        var scope = LogBuffer.BeginScope();
+
+        scope.Dispose();
+        var act = scope.Dispose;
+
+        act.Should().NotThrow();
+        scope.IsDisposed.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// Records logged after the scope is disposed are dropped rather than buffered.
+    /// </summary>
+    [Fact]
+    public void LoggingAfterDisposeDropsRecords()
+    {
+        var scope = LogBuffer.BeginScope();
+        scope.Dispose();
+
+        logger.LogDebug("late");
+        scope.Flush();
+
+        inner.Records.Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// A non-structured buffered state is captured and replayed as its message.
+    /// </summary>
+    [Fact]
+    public void NonStructuredStateIsReplayedAsMessage()
+    {
+        using var scope = LogBuffer.BeginScope();
+        logger.Log(LogLevel.Debug, default, "plain-state", null, (s, _) => s);
+
+        scope.Flush();
+
+        inner.Records.Should().ContainSingle().Which.Message.Should().Be("plain-state");
+    }
+}

--- a/src/JamesConsulting.Tests/Logging/RecordingLogger.cs
+++ b/src/JamesConsulting.Tests/Logging/RecordingLogger.cs
@@ -12,10 +12,15 @@ namespace JamesConsulting.Tests.Logging;
 internal sealed class RecordingLogger : ILogger
 {
     private readonly LogLevel enabledFrom;
+    private readonly List<RecordedLog> records;
 
-    public RecordingLogger(LogLevel enabledFrom = LogLevel.Trace) => this.enabledFrom = enabledFrom;
+    public RecordingLogger(LogLevel enabledFrom = LogLevel.Trace, List<RecordedLog>? sharedSink = null)
+    {
+        this.enabledFrom = enabledFrom;
+        records = sharedSink ?? new List<RecordedLog>();
+    }
 
-    public List<RecordedLog> Records { get; } = new();
+    public List<RecordedLog> Records => records;
 
     /// <summary>
     /// Optional hook that, when it returns <c>true</c> for a given level and rendered message, makes
@@ -35,6 +40,15 @@ internal sealed class RecordingLogger : ILogger
         Exception? exception,
         Func<TState, Exception?, string> formatter)
     {
+        // Model a real logger's own level filtering so the inner-logger path faithfully drops
+        // records the host configuration would suppress. The replay target is constructed enabled
+        // from Trace, so it records every dumped record unconditionally (mirroring the direct
+        // provider replay, which bypasses the factory filters).
+        if (!IsEnabled(logLevel))
+        {
+            return;
+        }
+
         var message = formatter(state, exception);
 
         if (ThrowOn?.Invoke(logLevel, message) == true)
@@ -45,7 +59,7 @@ internal sealed class RecordingLogger : ILogger
         IReadOnlyList<KeyValuePair<string, object?>>? structured =
             state as IReadOnlyList<KeyValuePair<string, object?>>;
 
-        Records.Add(new RecordedLog(logLevel, eventId, message, exception, structured));
+        records.Add(new RecordedLog(logLevel, eventId, message, exception, structured));
     }
 
     private sealed class NullScope : IDisposable

--- a/src/JamesConsulting.Tests/Logging/RecordingLogger.cs
+++ b/src/JamesConsulting.Tests/Logging/RecordingLogger.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
+
+namespace JamesConsulting.Tests.Logging;
+
+/// <summary>
+/// A minimal in-memory <see cref="ILogger" /> used by the buffering logger tests to capture the
+/// records that reach the inner logger. Records the level, event id, rendered message, exception,
+/// and any structured state so tests can assert on dump ordering and fidelity.
+/// </summary>
+internal sealed class RecordingLogger : ILogger
+{
+    private readonly LogLevel enabledFrom;
+
+    public RecordingLogger(LogLevel enabledFrom = LogLevel.Trace) => this.enabledFrom = enabledFrom;
+
+    public List<RecordedLog> Records { get; } = new();
+
+    /// <summary>
+    /// Optional hook that, when it returns <c>true</c> for a given level and rendered message, makes
+    /// the logger throw instead of recording — used to simulate a faulty sink during replay.
+    /// </summary>
+    public Func<LogLevel, string, bool>? ThrowOn { get; set; }
+
+    public IDisposable BeginScope<TState>(TState state)
+        where TState : notnull => NullScope.Instance;
+
+    public bool IsEnabled(LogLevel logLevel) => logLevel != LogLevel.None && logLevel >= enabledFrom;
+
+    public void Log<TState>(
+        LogLevel logLevel,
+        EventId eventId,
+        TState state,
+        Exception? exception,
+        Func<TState, Exception?, string> formatter)
+    {
+        var message = formatter(state, exception);
+
+        if (ThrowOn?.Invoke(logLevel, message) == true)
+        {
+            throw new InvalidOperationException("simulated sink failure");
+        }
+
+        IReadOnlyList<KeyValuePair<string, object?>>? structured =
+            state as IReadOnlyList<KeyValuePair<string, object?>>;
+
+        Records.Add(new RecordedLog(logLevel, eventId, message, exception, structured));
+    }
+
+    private sealed class NullScope : IDisposable
+    {
+        public static readonly NullScope Instance = new();
+
+        public void Dispose()
+        {
+        }
+    }
+}
+
+/// <summary>
+/// A captured log record from <see cref="RecordingLogger" />.
+/// </summary>
+internal sealed record RecordedLog(
+    LogLevel Level,
+    EventId EventId,
+    string Message,
+    Exception? Exception,
+    IReadOnlyList<KeyValuePair<string, object?>>? State);

--- a/src/JamesConsulting/JamesConsulting.csproj
+++ b/src/JamesConsulting/JamesConsulting.csproj
@@ -30,6 +30,10 @@
     </ItemGroup>
 
     <ItemGroup>
+        <InternalsVisibleTo Include="JamesConsulting.Tests" />
+    </ItemGroup>
+
+    <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
         <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.0" />
         <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.0" />

--- a/src/JamesConsulting/JamesConsulting.csproj
+++ b/src/JamesConsulting/JamesConsulting.csproj
@@ -30,7 +30,10 @@
     </ItemGroup>
 
     <ItemGroup>
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
         <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <PackageReference Include="Utf8Json" Version="1.3.7" />
     </ItemGroup>

--- a/src/JamesConsulting/Logging/BufferedLogEntry.cs
+++ b/src/JamesConsulting/Logging/BufferedLogEntry.cs
@@ -1,0 +1,147 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.Logging;
+
+namespace JamesConsulting.Logging;
+
+/// <summary>
+/// An immutable snapshot of a single buffered log record. Captured eagerly when a record is
+/// buffered so that replaying it later is safe even if the original state is mutated, pooled, or
+/// disposed after the originating <see cref="ILogger.Log{TState}" /> call returns. Structured state
+/// is copied pair-by-pair; scalar values (strings and value types such as numbers, enums,
+/// <see cref="DateTime" />, and <see cref="Guid" />) are preserved with their original type, while
+/// any other (potentially mutable) reference value is frozen to its log-time text via
+/// <see cref="object.ToString" />. This means an object-valued structured property
+/// (for example <c>logger.LogDebug("processing {Order}", order)</c>) is replayed as a string, so a
+/// destructuring sink receives the frozen text rather than the live object's properties — the safe
+/// trade-off for a dump buffer, since the object may be mutated or disposed before replay.
+/// </summary>
+internal sealed class BufferedLogEntry
+{
+    private static readonly Func<object?, Exception?, string> ReplayFormatter =
+        static (state, _) => state?.ToString() ?? string.Empty;
+
+    private readonly ILogger inner;
+    private readonly LogLevel level;
+    private readonly EventId eventId;
+    private readonly Exception? exception;
+    private readonly object? state;
+
+    private BufferedLogEntry(ILogger inner, LogLevel level, EventId eventId, object? state, Exception? exception)
+    {
+        this.inner = inner;
+        this.level = level;
+        this.eventId = eventId;
+        this.state = state;
+        this.exception = exception;
+    }
+
+    /// <summary>
+    /// Creates a snapshot of a log record, eagerly rendering its message and copying any structured
+    /// state so the entry can be replayed safely later.
+    /// </summary>
+    /// <typeparam name="TState">The type of the original log state.</typeparam>
+    /// <param name="inner">The inner logger that the entry replays to (the originating category).</param>
+    /// <param name="level">The original log level.</param>
+    /// <param name="eventId">The original event id.</param>
+    /// <param name="state">The original log state.</param>
+    /// <param name="message">The pre-rendered message text.</param>
+    /// <param name="exception">The original exception, if any.</param>
+    /// <returns>An immutable <see cref="BufferedLogEntry" />.</returns>
+    public static BufferedLogEntry Create<TState>(
+        ILogger inner,
+        LogLevel level,
+        EventId eventId,
+        TState state,
+        string message,
+        Exception? exception)
+    {
+        object? snapshot;
+        try
+        {
+            snapshot = state is IEnumerable<KeyValuePair<string, object?>> structured
+                ? new SnapshotState(Freeze(structured), message)
+                : (object?)message;
+        }
+        catch
+        {
+            // Snapshotting runs on the caller's logging path. A hostile or buggy structured state
+            // (for example an enumerable whose enumerator throws) must not surface as a logging
+            // failure; fall back to the already-rendered message text.
+            snapshot = message;
+        }
+
+        return new BufferedLogEntry(inner, level, eventId, snapshot, exception);
+    }
+
+    private static KeyValuePair<string, object?>[] Freeze(IEnumerable<KeyValuePair<string, object?>> structured)
+    {
+        var values = structured.ToArray();
+        for (var i = 0; i < values.Length; i++)
+        {
+            values[i] = new KeyValuePair<string, object?>(values[i].Key, FreezeValue(values[i].Value));
+        }
+
+        return values;
+    }
+
+    // Preserve scalars (immutable) by reference to keep structured typing; freeze any other reference
+    // value to its log-time text so a later mutation cannot change what a replayed record reports.
+    private static object? FreezeValue(object? value)
+    {
+        switch (value)
+        {
+            case null:
+            case string:
+            case ValueType:
+                return value;
+            default:
+                try
+                {
+                    return value.ToString();
+                }
+                catch
+                {
+                    // Freezing runs on the caller's logging path; a throwing ToString must not
+                    // surface as a logging failure. Fall back to the type name.
+                    return value.GetType().FullName;
+                }
+        }
+    }
+
+    /// <summary>
+    /// Replays the buffered record to its originating inner logger, preserving the original level,
+    /// event id, message, structured state, and exception.
+    /// </summary>
+    public void Replay() => inner.Log(level, eventId, state, exception, ReplayFormatter);
+
+    /// <summary>
+    /// A defensive copy of a structured log state that preserves the original key/value pairs and
+    /// the rendered message (via <see cref="ToString" />), so sinks that read structured state see
+    /// the same data on replay.
+    /// </summary>
+    private sealed class SnapshotState : IReadOnlyList<KeyValuePair<string, object?>>
+    {
+        private readonly KeyValuePair<string, object?>[] values;
+        private readonly string message;
+
+        public SnapshotState(KeyValuePair<string, object?>[] values, string message)
+        {
+            this.values = values;
+            this.message = message;
+        }
+
+        public int Count => values.Length;
+
+        public KeyValuePair<string, object?> this[int index] => values[index];
+
+        public IEnumerator<KeyValuePair<string, object?>> GetEnumerator() =>
+            ((IEnumerable<KeyValuePair<string, object?>>)values).GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => values.GetEnumerator();
+
+        public override string ToString() => message;
+    }
+}

--- a/src/JamesConsulting/Logging/BufferedLogEntry.cs
+++ b/src/JamesConsulting/Logging/BufferedLogEntry.cs
@@ -23,15 +23,15 @@ internal sealed class BufferedLogEntry
     private static readonly Func<object?, Exception?, string> ReplayFormatter =
         static (state, _) => state?.ToString() ?? string.Empty;
 
-    private readonly ILogger inner;
+    private readonly ILogger replayTarget;
     private readonly LogLevel level;
     private readonly EventId eventId;
     private readonly Exception? exception;
     private readonly object? state;
 
-    private BufferedLogEntry(ILogger inner, LogLevel level, EventId eventId, object? state, Exception? exception)
+    private BufferedLogEntry(ILogger replayTarget, LogLevel level, EventId eventId, object? state, Exception? exception)
     {
-        this.inner = inner;
+        this.replayTarget = replayTarget;
         this.level = level;
         this.eventId = eventId;
         this.state = state;
@@ -43,7 +43,7 @@ internal sealed class BufferedLogEntry
     /// state so the entry can be replayed safely later.
     /// </summary>
     /// <typeparam name="TState">The type of the original log state.</typeparam>
-    /// <param name="inner">The inner logger that the entry replays to (the originating category).</param>
+    /// <param name="replayTarget">The logger the entry replays to during a flush (the originating category, written directly to the providers).</param>
     /// <param name="level">The original log level.</param>
     /// <param name="eventId">The original event id.</param>
     /// <param name="state">The original log state.</param>
@@ -51,7 +51,7 @@ internal sealed class BufferedLogEntry
     /// <param name="exception">The original exception, if any.</param>
     /// <returns>An immutable <see cref="BufferedLogEntry" />.</returns>
     public static BufferedLogEntry Create<TState>(
-        ILogger inner,
+        ILogger replayTarget,
         LogLevel level,
         EventId eventId,
         TState state,
@@ -73,7 +73,7 @@ internal sealed class BufferedLogEntry
             snapshot = message;
         }
 
-        return new BufferedLogEntry(inner, level, eventId, snapshot, exception);
+        return new BufferedLogEntry(replayTarget, level, eventId, snapshot, exception);
     }
 
     private static KeyValuePair<string, object?>[] Freeze(IEnumerable<KeyValuePair<string, object?>> structured)
@@ -112,10 +112,10 @@ internal sealed class BufferedLogEntry
     }
 
     /// <summary>
-    /// Replays the buffered record to its originating inner logger, preserving the original level,
-    /// event id, message, structured state, and exception.
+    /// Replays the buffered record to its replay target, preserving the original level, event id,
+    /// message, structured state, and exception.
     /// </summary>
-    public void Replay() => inner.Log(level, eventId, state, exception, ReplayFormatter);
+    public void Replay() => replayTarget.Log(level, eventId, state, exception, ReplayFormatter);
 
     /// <summary>
     /// A defensive copy of a structured log state that preserves the original key/value pairs and

--- a/src/JamesConsulting/Logging/BufferingLogger.cs
+++ b/src/JamesConsulting/Logging/BufferingLogger.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Threading;
 using JamesConsulting.Internal;
 using Microsoft.Extensions.Logging;
 
@@ -7,34 +6,64 @@ namespace JamesConsulting.Logging;
 
 /// <summary>
 /// An <see cref="ILogger" /> decorator that implements the buffering ("dump-on-error") pattern.
-/// Low-level records are captured into the active <see cref="LogBufferScope" /> and only emitted if
-/// a record at or above the configured flush level occurs, at which point the entire buffer is
-/// dumped to the inner logger so you get the diagnostic context leading up to the failure.
+/// Records your host's live logging configuration would already write are written live, unchanged.
+/// Records below that live threshold but at or above the configured buffer level are captured into
+/// the active <see cref="LogBufferScope" /> and only emitted if a record at or above the configured
+/// flush level occurs inside that scope, at which point the entire buffer — and the triggering
+/// record — is replayed directly to the registered providers so you get the diagnostic context
+/// leading up to the failure.
 /// </summary>
 /// <remarks>
+/// <para>
 /// See <see cref="BufferingLoggerOptions" /> for the routing rules. The decorator forwards
 /// <see cref="ILogger.BeginScope{TState}" /> to the inner logger; buffered records do not capture
 /// logging-scope state.
+/// </para>
+/// <para>
+/// The live boundary is the unmodified inner logger's own <see cref="ILogger.IsEnabled" />, so the
+/// host's <c>Logging:LogLevel</c> configuration stays authoritative for live logging (including
+/// per-category and per-provider rules and configuration reloads). The error dump, by contrast, is
+/// written through a <em>replay target</em> that fans out directly to the registered providers and
+/// bypasses those factory-level filters — that is what makes the suppressed low-level context
+/// visible on error.
+/// </para>
+/// <para>
+/// One deliberate consequence: <em>inside an active scope</em> the filter bypass applies to the
+/// triggering flush-level record too, and <see cref="IsEnabled" /> reports <c>true</c> for
+/// flush-level records whenever a scope is active. So an error logged in a category or provider the
+/// host configuration has silenced still emits — along with the whole buffered dump — to every
+/// registered provider, because the error must reach the same sinks that just received its context.
+/// The same flush-level record logged <em>outside</em> a scope honors the host configuration
+/// normally. This type is internal; it is always constructed by <see cref="BufferingLoggerFactory" />
+/// with a provider-backed replay target.
+/// </para>
 /// </remarks>
-public sealed class BufferingLogger : ILogger
+internal sealed class BufferingLogger : ILogger
 {
     private readonly ILogger inner;
+    private readonly ILogger replayTarget;
     private readonly BufferingLoggerOptions options;
-    private int filterWarningEmitted;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="BufferingLogger" /> class.
     /// </summary>
-    /// <param name="inner">The inner logger that records are written through to and replayed against.</param>
+    /// <param name="inner">The inner logger used for live writes and for the authoritative live-level decision.</param>
+    /// <param name="replayTarget">
+    /// The logger buffered records and the error trigger are replayed to during a flush. Writes
+    /// directly to the registered providers, bypassing the Microsoft.Extensions.Logging factory
+    /// filters.
+    /// </param>
     /// <param name="options">The buffering configuration. Validated by the constructor.</param>
-    /// <exception cref="ArgumentNullException"><paramref name="inner" /> or <paramref name="options" /> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="inner" />, <paramref name="replayTarget" />, or <paramref name="options" /> is <c>null</c>.</exception>
     /// <exception cref="ArgumentOutOfRangeException">The options fail <see cref="BufferingLoggerOptions.Validate" />.</exception>
-    public BufferingLogger(ILogger inner, BufferingLoggerOptions options)
+    public BufferingLogger(ILogger inner, ILogger replayTarget, BufferingLoggerOptions options)
     {
         Guard.NotNull(inner);
+        Guard.NotNull(replayTarget);
         Guard.NotNull(options);
         options.Validate();
         this.inner = inner;
+        this.replayTarget = replayTarget;
         this.options = options;
     }
 
@@ -50,11 +79,18 @@ public sealed class BufferingLogger : ILogger
             return false;
         }
 
-        if (logLevel >= options.PassthroughLevel)
+        if (logLevel >= options.FlushLevel)
         {
-            // Passthrough and flush levels are written live; honour the inner logger's filter, but
-            // always allow flush-level records through so the dump can be triggered.
-            return inner.IsEnabled(logLevel) || logLevel >= options.FlushLevel;
+            // Flush-level records are written live when the host configuration allows it, and are
+            // also worth producing whenever there is an active scope to flush — even if the live
+            // configuration would suppress them — because they trigger the dump.
+            return inner.IsEnabled(logLevel) || HasActiveScope();
+        }
+
+        if (inner.IsEnabled(logLevel))
+        {
+            // The host configuration writes this level live; nothing for the buffer to decide.
+            return true;
         }
 
         if (logLevel >= options.BufferLevel)
@@ -66,9 +102,10 @@ public sealed class BufferingLogger : ILogger
                 return false;
             }
 
-            return options.SuspendBufferingAfterFlush && scope.IsFlushed
-                ? inner.IsEnabled(logLevel)
-                : true;
+            // After a flush with suspend-after-flush enabled, further buffer-range records are
+            // written live, so they are only enabled if the host configuration would write them
+            // (which it would not here, since inner.IsEnabled returned false above).
+            return !(options.SuspendBufferingAfterFlush && scope.IsFlushed);
         }
 
         return false;
@@ -91,27 +128,42 @@ public sealed class BufferingLogger : ILogger
 
         if (logLevel >= options.FlushLevel)
         {
-            // Dump the accrued context first, then write the triggering record. Flush is
-            // best-effort and never throws, so the triggering record is always written. The whole
-            // live scope chain is dumped (ancestors first) for chronological context; only the
-            // innermost scope is suspended.
-            var flushScope = LogBuffer.Current;
-            flushScope?.FlushForError();
+            var scope = LogBuffer.Current;
+            var hasScope = scope is not null && !scope.IsDisposed;
 
-            // Only warn about a filtered dump when a dump was actually attempted (a scope is
-            // active). A bare flush-level record outside any buffering scope dumps nothing, so it
-            // must not raise the backstop warning or consume the once-only guard.
-            if (flushScope is not null)
+            if (hasScope)
             {
-                WarnIfDumpFiltered();
+                // Dump the accrued context first (replayed directly to every provider), then write
+                // the triggering record the same way so every sink that just received the buffered
+                // context also receives the error that explains it. Flush is best-effort and never
+                // throws, so the triggering record is always written.
+                scope!.FlushForError();
+                if (ReplayHasSinks())
+                {
+                    replayTarget.Log(logLevel, eventId, state, exception, formatter);
+                }
+                else
+                {
+                    // The replay target reaches no providers — for example a custom inner factory
+                    // whose providers were not supplied to this logger. The buffered context cannot
+                    // be surfaced (the inner filter would suppress it), but the triggering record
+                    // must not be lost, so fall back to the inner logger for it.
+                    inner.Log(logLevel, eventId, state, exception, formatter);
+                }
+
+                return;
             }
 
+            // No scope to dump: there is no buffered context, so the record follows the host's live
+            // configuration exactly as it would without buffering. The host LogLevel stays
+            // authoritative — a suppressed flush-level record stays suppressed.
             inner.Log(logLevel, eventId, state, exception, formatter);
             return;
         }
 
-        if (logLevel >= options.PassthroughLevel)
+        if (inner.IsEnabled(logLevel))
         {
+            // The host configuration writes this level live.
             inner.Log(logLevel, eventId, state, exception, formatter);
             return;
         }
@@ -121,30 +173,35 @@ public sealed class BufferingLogger : ILogger
             return;
         }
 
-        var scope = LogBuffer.Current;
-        if (scope is null || scope.IsDisposed)
+        var bufferScope = LogBuffer.Current;
+        if (bufferScope is null || bufferScope.IsDisposed)
         {
             // No active scope to buffer into: drop the record rather than emit unscoped noise.
             return;
         }
 
-        if (options.SuspendBufferingAfterFlush && scope.IsFlushed)
+        if (options.SuspendBufferingAfterFlush && bufferScope.IsFlushed)
         {
-            // Fast path: already flushed once, so emit subsequent buffer-range records live without
-            // allocating a snapshot. The authoritative, race-free decision is still made under the
-            // scope lock in TryEnqueue below for the case where a flush happens concurrently.
-            inner.Log(logLevel, eventId, state, exception, formatter);
+            // Fast path: already flushed once. Buffering is suspended, but the host configuration
+            // does not write this level live (inner.IsEnabled was false), so there is nothing to do.
             return;
         }
 
         var message = RenderMessage(state, exception, formatter);
-        var entry = BufferedLogEntry.Create(inner, logLevel, eventId, state, message, exception);
-        if (scope.TryEnqueue(entry, options.SuspendBufferingAfterFlush) == LogBufferEnqueueResult.AlreadyFlushed)
-        {
-            // A concurrent flush completed between the check above and the enqueue; emit live.
-            inner.Log(logLevel, eventId, state, exception, formatter);
-        }
+        var entry = BufferedLogEntry.Create(replayTarget, logLevel, eventId, state, message, exception);
+        bufferScope.TryEnqueue(entry, options.SuspendBufferingAfterFlush);
     }
+
+    private static bool HasActiveScope()
+    {
+        var scope = LogBuffer.Current;
+        return scope is not null && !scope.IsDisposed;
+    }
+
+    // The replay target is the direct-to-providers logger except in tests; treat any non-replay
+    // logger as always having a sink so it is used unchanged. A ProviderReplayLogger with no
+    // providers has no sink, so the triggering record falls back to the inner logger.
+    private bool ReplayHasSinks() => replayTarget is not ProviderReplayLogger replay || replay.HasSinks;
 
     private static string RenderMessage<TState>(
         TState state,
@@ -163,46 +220,5 @@ public sealed class BufferingLogger : ILogger
         {
             return $"[buffering logger: message formatter threw {ex.GetType().FullName}]";
         }
-    }
-
-    private void WarnIfDumpFiltered()
-    {
-        // The buffered band is [BufferLevel, PassthroughLevel). When it is empty nothing is ever
-        // buffered, so there is no dump to filter.
-        if (options.PassthroughLevel <= options.BufferLevel)
-        {
-            return;
-        }
-
-        // Log levels are monotonic for a given logger: if the highest level that can be buffered is
-        // disabled, every lower buffered level is disabled too, so no dumped record can reach a
-        // sink. If that top level is still enabled, at least part of the dump gets through and the
-        // warning would be misleading.
-        var highestBufferedLevel = (LogLevel)((int)options.PassthroughLevel - 1);
-        if (inner.IsEnabled(highestBufferedLevel))
-        {
-            return;
-        }
-
-        // The inner logger filters out the entire buffered band, so the dump just replayed cannot
-        // reach the sinks. Warn once per logger so the misconfiguration is visible without flooding
-        // output. This only happens when ConfigureUnderlyingFilter is disabled or a category rule
-        // blocks the buffered levels.
-        if (Interlocked.Exchange(ref filterWarningEmitted, 1) != 0)
-        {
-            return;
-        }
-
-        var message =
-            $"Buffering logger: buffered records below {options.PassthroughLevel} are filtered out by the underlying " +
-            $"logging configuration, so the dumped context will not reach any sink. Add a filter rule at " +
-            $"{options.BufferLevel} for the buffered categories (for example set Logging:LogLevel:Default to Trace) " +
-            "or leave BufferingLoggerOptions.ConfigureUnderlyingFilter enabled.";
-
-        // Emit at the flush level (which just triggered and is written live) when that is higher than
-        // Warning, so the backstop warning cannot itself be filtered out by the same misconfiguration
-        // it is reporting.
-        var warnLevel = options.FlushLevel > LogLevel.Warning ? options.FlushLevel : LogLevel.Warning;
-        inner.Log(warnLevel, default, message, null, static (s, _) => s);
     }
 }

--- a/src/JamesConsulting/Logging/BufferingLogger.cs
+++ b/src/JamesConsulting/Logging/BufferingLogger.cs
@@ -1,0 +1,208 @@
+﻿using System;
+using System.Threading;
+using JamesConsulting.Internal;
+using Microsoft.Extensions.Logging;
+
+namespace JamesConsulting.Logging;
+
+/// <summary>
+/// An <see cref="ILogger" /> decorator that implements the buffering ("dump-on-error") pattern.
+/// Low-level records are captured into the active <see cref="LogBufferScope" /> and only emitted if
+/// a record at or above the configured flush level occurs, at which point the entire buffer is
+/// dumped to the inner logger so you get the diagnostic context leading up to the failure.
+/// </summary>
+/// <remarks>
+/// See <see cref="BufferingLoggerOptions" /> for the routing rules. The decorator forwards
+/// <see cref="ILogger.BeginScope{TState}" /> to the inner logger; buffered records do not capture
+/// logging-scope state.
+/// </remarks>
+public sealed class BufferingLogger : ILogger
+{
+    private readonly ILogger inner;
+    private readonly BufferingLoggerOptions options;
+    private int filterWarningEmitted;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BufferingLogger" /> class.
+    /// </summary>
+    /// <param name="inner">The inner logger that records are written through to and replayed against.</param>
+    /// <param name="options">The buffering configuration. Validated by the constructor.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="inner" /> or <paramref name="options" /> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">The options fail <see cref="BufferingLoggerOptions.Validate" />.</exception>
+    public BufferingLogger(ILogger inner, BufferingLoggerOptions options)
+    {
+        Guard.NotNull(inner);
+        Guard.NotNull(options);
+        options.Validate();
+        this.inner = inner;
+        this.options = options;
+    }
+
+    /// <inheritdoc />
+    public IDisposable? BeginScope<TState>(TState state)
+        where TState : notnull => inner.BeginScope(state);
+
+    /// <inheritdoc />
+    public bool IsEnabled(LogLevel logLevel)
+    {
+        if (logLevel == LogLevel.None)
+        {
+            return false;
+        }
+
+        if (logLevel >= options.PassthroughLevel)
+        {
+            // Passthrough and flush levels are written live; honour the inner logger's filter, but
+            // always allow flush-level records through so the dump can be triggered.
+            return inner.IsEnabled(logLevel) || logLevel >= options.FlushLevel;
+        }
+
+        if (logLevel >= options.BufferLevel)
+        {
+            // Buffer-range records are only worth producing when there is somewhere to buffer them.
+            var scope = LogBuffer.Current;
+            if (scope is null || scope.IsDisposed)
+            {
+                return false;
+            }
+
+            return options.SuspendBufferingAfterFlush && scope.IsFlushed
+                ? inner.IsEnabled(logLevel)
+                : true;
+        }
+
+        return false;
+    }
+
+    /// <inheritdoc />
+    public void Log<TState>(
+        LogLevel logLevel,
+        EventId eventId,
+        TState state,
+        Exception? exception,
+        Func<TState, Exception?, string> formatter)
+    {
+        Guard.NotNull(formatter);
+
+        if (logLevel == LogLevel.None)
+        {
+            return;
+        }
+
+        if (logLevel >= options.FlushLevel)
+        {
+            // Dump the accrued context first, then write the triggering record. Flush is
+            // best-effort and never throws, so the triggering record is always written. The whole
+            // live scope chain is dumped (ancestors first) for chronological context; only the
+            // innermost scope is suspended.
+            var flushScope = LogBuffer.Current;
+            flushScope?.FlushForError();
+
+            // Only warn about a filtered dump when a dump was actually attempted (a scope is
+            // active). A bare flush-level record outside any buffering scope dumps nothing, so it
+            // must not raise the backstop warning or consume the once-only guard.
+            if (flushScope is not null)
+            {
+                WarnIfDumpFiltered();
+            }
+
+            inner.Log(logLevel, eventId, state, exception, formatter);
+            return;
+        }
+
+        if (logLevel >= options.PassthroughLevel)
+        {
+            inner.Log(logLevel, eventId, state, exception, formatter);
+            return;
+        }
+
+        if (logLevel < options.BufferLevel)
+        {
+            return;
+        }
+
+        var scope = LogBuffer.Current;
+        if (scope is null || scope.IsDisposed)
+        {
+            // No active scope to buffer into: drop the record rather than emit unscoped noise.
+            return;
+        }
+
+        if (options.SuspendBufferingAfterFlush && scope.IsFlushed)
+        {
+            // Fast path: already flushed once, so emit subsequent buffer-range records live without
+            // allocating a snapshot. The authoritative, race-free decision is still made under the
+            // scope lock in TryEnqueue below for the case where a flush happens concurrently.
+            inner.Log(logLevel, eventId, state, exception, formatter);
+            return;
+        }
+
+        var message = RenderMessage(state, exception, formatter);
+        var entry = BufferedLogEntry.Create(inner, logLevel, eventId, state, message, exception);
+        if (scope.TryEnqueue(entry, options.SuspendBufferingAfterFlush) == LogBufferEnqueueResult.AlreadyFlushed)
+        {
+            // A concurrent flush completed between the check above and the enqueue; emit live.
+            inner.Log(logLevel, eventId, state, exception, formatter);
+        }
+    }
+
+    private static string RenderMessage<TState>(
+        TState state,
+        Exception? exception,
+        Func<TState, Exception?, string> formatter)
+    {
+        // Buffer-range records are rendered eagerly so the message reflects the values at log time
+        // (the live logging pipeline would otherwise render lazily at write time). Guard the caller's
+        // formatter so a throwing message — for example a structured value whose ToString throws —
+        // cannot surface as a logging failure on the caller's hot path.
+        try
+        {
+            return formatter(state, exception);
+        }
+        catch (Exception ex)
+        {
+            return $"[buffering logger: message formatter threw {ex.GetType().FullName}]";
+        }
+    }
+
+    private void WarnIfDumpFiltered()
+    {
+        // The buffered band is [BufferLevel, PassthroughLevel). When it is empty nothing is ever
+        // buffered, so there is no dump to filter.
+        if (options.PassthroughLevel <= options.BufferLevel)
+        {
+            return;
+        }
+
+        // Log levels are monotonic for a given logger: if the highest level that can be buffered is
+        // disabled, every lower buffered level is disabled too, so no dumped record can reach a
+        // sink. If that top level is still enabled, at least part of the dump gets through and the
+        // warning would be misleading.
+        var highestBufferedLevel = (LogLevel)((int)options.PassthroughLevel - 1);
+        if (inner.IsEnabled(highestBufferedLevel))
+        {
+            return;
+        }
+
+        // The inner logger filters out the entire buffered band, so the dump just replayed cannot
+        // reach the sinks. Warn once per logger so the misconfiguration is visible without flooding
+        // output. This only happens when ConfigureUnderlyingFilter is disabled or a category rule
+        // blocks the buffered levels.
+        if (Interlocked.Exchange(ref filterWarningEmitted, 1) != 0)
+        {
+            return;
+        }
+
+        var message =
+            $"Buffering logger: buffered records below {options.PassthroughLevel} are filtered out by the underlying " +
+            $"logging configuration, so the dumped context will not reach any sink. Add a filter rule at " +
+            $"{options.BufferLevel} for the buffered categories (for example set Logging:LogLevel:Default to Trace) " +
+            "or leave BufferingLoggerOptions.ConfigureUnderlyingFilter enabled.";
+
+        // Emit at the flush level (which just triggered and is written live) when that is higher than
+        // Warning, so the backstop warning cannot itself be filtered out by the same misconfiguration
+        // it is reporting.
+        var warnLevel = options.FlushLevel > LogLevel.Warning ? options.FlushLevel : LogLevel.Warning;
+        inner.Log(warnLevel, default, message, null, static (s, _) => s);
+    }
+}

--- a/src/JamesConsulting/Logging/BufferingLoggerFactory.cs
+++ b/src/JamesConsulting/Logging/BufferingLoggerFactory.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using JamesConsulting.Internal;
+using Microsoft.Extensions.Logging;
+
+namespace JamesConsulting.Logging;
+
+/// <summary>
+/// An <see cref="ILoggerFactory" /> decorator that wraps every logger produced by an inner factory
+/// in a <see cref="BufferingLogger" />, so the buffering ("dump-on-error") behaviour applies across
+/// all categories without changing call sites.
+/// </summary>
+public sealed class BufferingLoggerFactory : ILoggerFactory
+{
+    private readonly ILoggerFactory inner;
+    private readonly BufferingLoggerOptions options;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BufferingLoggerFactory" /> class.
+    /// </summary>
+    /// <param name="inner">The inner factory whose loggers are wrapped.</param>
+    /// <param name="options">The buffering configuration applied to every produced logger. Validated by the constructor.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="inner" /> or <paramref name="options" /> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">The options fail <see cref="BufferingLoggerOptions.Validate" />.</exception>
+    public BufferingLoggerFactory(ILoggerFactory inner, BufferingLoggerOptions options)
+    {
+        Guard.NotNull(inner);
+        Guard.NotNull(options);
+        options.Validate();
+        this.inner = inner;
+        this.options = options;
+    }
+
+    /// <inheritdoc />
+    public ILogger CreateLogger(string categoryName) =>
+        new BufferingLogger(inner.CreateLogger(categoryName), options);
+
+    /// <inheritdoc />
+    public void AddProvider(ILoggerProvider provider) => inner.AddProvider(provider);
+
+    /// <summary>
+    /// Disposes the inner factory.
+    /// </summary>
+    public void Dispose() => inner.Dispose();
+}

--- a/src/JamesConsulting/Logging/BufferingLoggerFactory.cs
+++ b/src/JamesConsulting/Logging/BufferingLoggerFactory.cs
@@ -1,4 +1,7 @@
 ﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
 using JamesConsulting.Internal;
 using Microsoft.Extensions.Logging;
 
@@ -9,36 +12,82 @@ namespace JamesConsulting.Logging;
 /// in a <see cref="BufferingLogger" />, so the buffering ("dump-on-error") behaviour applies across
 /// all categories without changing call sites.
 /// </summary>
+/// <remarks>
+/// The factory also tracks the registered <see cref="ILoggerProvider" /> instances so that, on an
+/// error-triggered flush, buffered records can be replayed directly to the providers — bypassing the
+/// Microsoft.Extensions.Logging factory-level filters. The provider set is seeded from the ones
+/// supplied at construction (resolved from DI) and extended by <see cref="AddProvider" />.
+/// </remarks>
 public sealed class BufferingLoggerFactory : ILoggerFactory
 {
     private readonly ILoggerFactory inner;
     private readonly BufferingLoggerOptions options;
+    private readonly object gate = new();
+    private readonly List<ILoggerProvider> providers;
+    private readonly ConcurrentDictionary<string, ILogger> loggers = new(StringComparer.Ordinal);
 
     /// <summary>
     /// Initializes a new instance of the <see cref="BufferingLoggerFactory" /> class.
     /// </summary>
     /// <param name="inner">The inner factory whose loggers are wrapped.</param>
+    /// <param name="providers">
+    /// The logging providers buffered records are replayed to on flush. Typically the same providers
+    /// registered with the inner factory (resolved from DI). Providers added later via
+    /// <see cref="AddProvider" /> are included too.
+    /// </param>
     /// <param name="options">The buffering configuration applied to every produced logger. Validated by the constructor.</param>
-    /// <exception cref="ArgumentNullException"><paramref name="inner" /> or <paramref name="options" /> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="inner" />, <paramref name="providers" />, or <paramref name="options" /> is <c>null</c>.</exception>
     /// <exception cref="ArgumentOutOfRangeException">The options fail <see cref="BufferingLoggerOptions.Validate" />.</exception>
-    public BufferingLoggerFactory(ILoggerFactory inner, BufferingLoggerOptions options)
+    public BufferingLoggerFactory(ILoggerFactory inner, IEnumerable<ILoggerProvider> providers, BufferingLoggerOptions options)
     {
         Guard.NotNull(inner);
+        Guard.NotNull(providers);
         Guard.NotNull(options);
         options.Validate();
         this.inner = inner;
         this.options = options;
+        this.providers = providers.Where(static p => p is not null).Distinct().ToList();
     }
 
     /// <inheritdoc />
+    /// <remarks>
+    /// Loggers are cached per category name (ordinal), so repeated calls for the same category
+    /// return the same instance, matching the Microsoft.Extensions.Logging factory contract.
+    /// Caching is safe with respect to providers added later via <see cref="AddProvider" /> because
+    /// each logger resolves the live provider set at write time through <see cref="SnapshotProviders" />.
+    /// </remarks>
     public ILogger CreateLogger(string categoryName) =>
-        new BufferingLogger(inner.CreateLogger(categoryName), options);
+        loggers.GetOrAdd(
+            categoryName,
+            name => new BufferingLogger(
+                inner.CreateLogger(name),
+                new ProviderReplayLogger(name, SnapshotProviders),
+                options));
 
     /// <inheritdoc />
-    public void AddProvider(ILoggerProvider provider) => inner.AddProvider(provider);
+    public void AddProvider(ILoggerProvider provider)
+    {
+        Guard.NotNull(provider);
+        inner.AddProvider(provider);
+        lock (gate)
+        {
+            if (!providers.Contains(provider))
+            {
+                providers.Add(provider);
+            }
+        }
+    }
 
     /// <summary>
     /// Disposes the inner factory.
     /// </summary>
     public void Dispose() => inner.Dispose();
+
+    private ILoggerProvider[] SnapshotProviders()
+    {
+        lock (gate)
+        {
+            return providers.ToArray();
+        }
+    }
 }

--- a/src/JamesConsulting/Logging/BufferingLoggerOptions.cs
+++ b/src/JamesConsulting/Logging/BufferingLoggerOptions.cs
@@ -8,37 +8,50 @@ namespace JamesConsulting.Logging;
 /// </summary>
 /// <remarks>
 /// <para>
-/// The buffering logger routes each record using three thresholds, which must satisfy the
-/// invariant <c>BufferLevel &lt;= PassthroughLevel &lt;= FlushLevel</c>:
+/// The buffering logger leaves your host's live logging threshold (for example
+/// <c>Logging:LogLevel:Default</c>) completely untouched and authoritative — that configuration
+/// still decides which records are written live, exactly as it does without buffering. On top of
+/// that, two thresholds control buffering, which must satisfy <c>BufferLevel &lt;= FlushLevel</c>:
 /// </para>
 /// <list type="bullet">
 ///     <item>
-///         Records below <see cref="BufferLevel" /> are dropped.
+///         A record whose level your live configuration would already write is written live as
+///         normal — buffering does not change it.
 ///     </item>
 ///     <item>
-///         Records in the range <c>[BufferLevel, PassthroughLevel)</c> are captured into the
-///         active <see cref="LogBufferScope" /> and only emitted if a flush occurs.
+///         A record <em>below</em> the live threshold but at or above <see cref="BufferLevel" /> is
+///         captured into the active <see cref="LogBufferScope" /> (and dropped if no scope is
+///         active), so it is only emitted if a flush occurs.
 ///     </item>
 ///     <item>
-///         Records in the range <c>[PassthroughLevel, FlushLevel)</c> are written through to the
-///         inner logger immediately (normal logging).
+///         A record below <see cref="BufferLevel" /> is dropped.
 ///     </item>
 ///     <item>
-///         Records at or above <see cref="FlushLevel" /> flush the active scope (emitting every
-///         buffered record) and are then written through immediately.
+///         A record at or above <see cref="FlushLevel" /> that occurs inside an active scope flushes
+///         that scope: every buffered record — and the triggering record — is replayed directly to
+///         the registered logging providers so you get the diagnostic context leading up to the
+///         failure. Outside a scope there is nothing to dump, so the record follows your normal live
+///         configuration.
 ///     </item>
 /// </list>
 /// <para>
-/// Because the buffering logger decorates the inner <see cref="ILogger" />, replayed records still
-/// pass through the inner logger's own level filtering. A plain
-/// <c>SetMinimumLevel(LogLevel.Trace)</c> is <em>not</em> sufficient: when the host binds a
-/// configuration section such as <c>Logging:LogLevel:Default</c>, the resulting catch-all filter
-/// rule takes precedence over the minimum level, so flushed Debug/Trace records are silently
-/// discarded. Instead, ensure a filter <em>rule</em> at <see cref="BufferLevel" /> applies to the
-/// buffered categories — for example set <c>Logging:LogLevel:Default</c> to <c>Trace</c>, or call
-/// <c>AddFilter(null, LogLevel.Trace)</c>. By default <see cref="ConfigureUnderlyingFilter" /> wires
-/// this up for you. During normal operation nothing below <see cref="PassthroughLevel" /> is
-/// forwarded to the inner logger, so your sinks stay quiet until a flush is triggered.
+/// The replayed dump is written <em>directly</em> to the registered providers and therefore bypasses
+/// the Microsoft.Extensions.Logging factory-level filters (category, provider, and
+/// <c>Logging:LogLevel</c> rules). This is deliberate: the whole point of a dump-on-error buffer is
+/// to surface low-level context that your live configuration suppresses, so no extra filter
+/// configuration is required for the dump to reach your sinks. It also means an error replays the
+/// buffered context to every registered provider, even one whose own configured level would normally
+/// exclude those records.
+/// </para>
+/// <para>
+/// The filter bypass extends to the triggering record itself. <em>Inside an active scope</em>, a
+/// record at or above <see cref="FlushLevel" /> is force-routed to every registered provider together
+/// with the dump, and <see cref="BufferingLogger.IsEnabled" /> reports <c>true</c> for flush-level
+/// records whenever a scope is active. So if your configuration has silenced a category or provider,
+/// an error logged in that category inside a scope <em>still emits</em> — the error and its buffered
+/// context, to every provider — because the trigger must reach the same sinks that just received its
+/// context. The same flush-level record logged <em>outside</em> a scope honors your live
+/// configuration normally.
 /// </para>
 /// </remarks>
 public sealed class BufferingLoggerOptions
@@ -50,79 +63,45 @@ public sealed class BufferingLoggerOptions
     public LogLevel BufferLevel { get; set; } = LogLevel.Trace;
 
     /// <summary>
-    /// Gets or sets the level at or above which records are always written through to the inner
-    /// logger immediately (normal logging). Defaults to <see cref="LogLevel.Information" />.
-    /// </summary>
-    public LogLevel PassthroughLevel { get; set; } = LogLevel.Information;
-
-    /// <summary>
     /// Gets or sets the level at or above which a record flushes the active
-    /// <see cref="LogBufferScope" />, emitting every buffered record before the triggering record is
-    /// written. Defaults to <see cref="LogLevel.Error" />.
+    /// <see cref="LogBufferScope" />, replaying every buffered record and the triggering record
+    /// directly to the registered providers. Defaults to <see cref="LogLevel.Error" />.
     /// </summary>
     public LogLevel FlushLevel { get; set; } = LogLevel.Error;
 
     /// <summary>
     /// Gets or sets a value indicating whether buffering is suspended for the remainder of a scope
     /// after it has been flushed. When <c>true</c> (the default), buffer-range records that occur
-    /// after a flush are written through live instead of re-buffered, matching the behaviour of the
-    /// built-in .NET log buffering. When <c>false</c>, the scope resumes buffering after a flush.
-    /// </summary>
-    public bool SuspendBufferingAfterFlush { get; set; } = true;
-
-    /// <summary>
-    /// Gets or sets a value indicating whether <c>AddBufferingLogging</c> automatically lowers the
-    /// underlying logging filter so that flushed buffer-range records can reach your sinks. When
-    /// <c>true</c> (the default), a catch-all filter rule at <see cref="BufferLevel" /> is appended
-    /// as the last (and therefore winning) <em>no-category</em> rule, and the minimum level is
-    /// lowered to <see cref="BufferLevel" /> if it was higher.
+    /// after a flush honor the host's live configuration instead of being re-buffered (so a record
+    /// below the live threshold is dropped), matching the behaviour of the built-in .NET log
+    /// buffering. When <c>false</c>, the scope resumes buffering after a flush.
     /// </summary>
     /// <remarks>
-    /// <para>
-    /// This wins over a configuration-bound <c>Logging:LogLevel:Default</c> rule, but it does
-    /// <em>not</em> override more specific category- or provider-scoped rules (for example
-    /// <c>Logging:LogLevel:MyApp</c> or <c>Logging:Console:LogLevel:Default</c>); dumps for those
-    /// categories remain filtered, and the buffering logger emits a one-time warning when it detects
-    /// this.
-    /// </para>
-    /// <para>
-    /// Because the rule is level-based, lowering the effective default filter also makes
-    /// passthrough-band records (at or above <see cref="PassthroughLevel" />) visible live where a
-    /// higher configured default level would have suppressed them. Set this to <c>false</c> if you
-    /// need to control the underlying filter yourself; in that case you must ensure a filter rule at
-    /// <see cref="BufferLevel" /> applies to the buffered categories, otherwise dumped context is
-    /// discarded by the inner logger's filtering.
-    /// </para>
+    /// A consequence of the default <c>true</c> is that a scope dumps context at most once: after the
+    /// first flush no further records are buffered, so a second error later in the same long-lived
+    /// scope dumps nothing. Use one scope per logical operation (or set this to <c>false</c>) if you
+    /// want every error to carry its own buffered context.
     /// </remarks>
-    public bool ConfigureUnderlyingFilter { get; set; } = true;
+    public bool SuspendBufferingAfterFlush { get; set; } = true;
 
     /// <summary>
     /// Validates that the configured thresholds satisfy the required invariant.
     /// </summary>
     /// <exception cref="ArgumentOutOfRangeException">
-    /// Any threshold is <see cref="LogLevel.None" />, or the invariant
-    /// <c>BufferLevel &lt;= PassthroughLevel &lt;= FlushLevel</c> is violated.
+    /// <see cref="BufferLevel" /> or <see cref="FlushLevel" /> is <see cref="LogLevel.None" />, or
+    /// the invariant <c>BufferLevel &lt;= FlushLevel</c> is violated.
     /// </exception>
     public void Validate()
     {
         EnsureReal(BufferLevel, nameof(BufferLevel));
-        EnsureReal(PassthroughLevel, nameof(PassthroughLevel));
         EnsureReal(FlushLevel, nameof(FlushLevel));
 
-        if (BufferLevel > PassthroughLevel)
-        {
-            throw new ArgumentOutOfRangeException(
-                nameof(PassthroughLevel),
-                PassthroughLevel,
-                $"{nameof(PassthroughLevel)} ({PassthroughLevel}) must be greater than or equal to {nameof(BufferLevel)} ({BufferLevel}).");
-        }
-
-        if (PassthroughLevel > FlushLevel)
+        if (BufferLevel > FlushLevel)
         {
             throw new ArgumentOutOfRangeException(
                 nameof(FlushLevel),
                 FlushLevel,
-                $"{nameof(FlushLevel)} ({FlushLevel}) must be greater than or equal to {nameof(PassthroughLevel)} ({PassthroughLevel}).");
+                $"{nameof(FlushLevel)} ({FlushLevel}) must be greater than or equal to {nameof(BufferLevel)} ({BufferLevel}).");
         }
     }
 

--- a/src/JamesConsulting/Logging/BufferingLoggerOptions.cs
+++ b/src/JamesConsulting/Logging/BufferingLoggerOptions.cs
@@ -1,0 +1,136 @@
+﻿using System;
+using Microsoft.Extensions.Logging;
+
+namespace JamesConsulting.Logging;
+
+/// <summary>
+/// Configuration for the buffering ("dump-on-error") logger.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The buffering logger routes each record using three thresholds, which must satisfy the
+/// invariant <c>BufferLevel &lt;= PassthroughLevel &lt;= FlushLevel</c>:
+/// </para>
+/// <list type="bullet">
+///     <item>
+///         Records below <see cref="BufferLevel" /> are dropped.
+///     </item>
+///     <item>
+///         Records in the range <c>[BufferLevel, PassthroughLevel)</c> are captured into the
+///         active <see cref="LogBufferScope" /> and only emitted if a flush occurs.
+///     </item>
+///     <item>
+///         Records in the range <c>[PassthroughLevel, FlushLevel)</c> are written through to the
+///         inner logger immediately (normal logging).
+///     </item>
+///     <item>
+///         Records at or above <see cref="FlushLevel" /> flush the active scope (emitting every
+///         buffered record) and are then written through immediately.
+///     </item>
+/// </list>
+/// <para>
+/// Because the buffering logger decorates the inner <see cref="ILogger" />, replayed records still
+/// pass through the inner logger's own level filtering. A plain
+/// <c>SetMinimumLevel(LogLevel.Trace)</c> is <em>not</em> sufficient: when the host binds a
+/// configuration section such as <c>Logging:LogLevel:Default</c>, the resulting catch-all filter
+/// rule takes precedence over the minimum level, so flushed Debug/Trace records are silently
+/// discarded. Instead, ensure a filter <em>rule</em> at <see cref="BufferLevel" /> applies to the
+/// buffered categories — for example set <c>Logging:LogLevel:Default</c> to <c>Trace</c>, or call
+/// <c>AddFilter(null, LogLevel.Trace)</c>. By default <see cref="ConfigureUnderlyingFilter" /> wires
+/// this up for you. During normal operation nothing below <see cref="PassthroughLevel" /> is
+/// forwarded to the inner logger, so your sinks stay quiet until a flush is triggered.
+/// </para>
+/// </remarks>
+public sealed class BufferingLoggerOptions
+{
+    /// <summary>
+    /// Gets or sets the lowest level captured into the buffer. Records below this level are dropped
+    /// entirely. Defaults to <see cref="LogLevel.Trace" />.
+    /// </summary>
+    public LogLevel BufferLevel { get; set; } = LogLevel.Trace;
+
+    /// <summary>
+    /// Gets or sets the level at or above which records are always written through to the inner
+    /// logger immediately (normal logging). Defaults to <see cref="LogLevel.Information" />.
+    /// </summary>
+    public LogLevel PassthroughLevel { get; set; } = LogLevel.Information;
+
+    /// <summary>
+    /// Gets or sets the level at or above which a record flushes the active
+    /// <see cref="LogBufferScope" />, emitting every buffered record before the triggering record is
+    /// written. Defaults to <see cref="LogLevel.Error" />.
+    /// </summary>
+    public LogLevel FlushLevel { get; set; } = LogLevel.Error;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether buffering is suspended for the remainder of a scope
+    /// after it has been flushed. When <c>true</c> (the default), buffer-range records that occur
+    /// after a flush are written through live instead of re-buffered, matching the behaviour of the
+    /// built-in .NET log buffering. When <c>false</c>, the scope resumes buffering after a flush.
+    /// </summary>
+    public bool SuspendBufferingAfterFlush { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether <c>AddBufferingLogging</c> automatically lowers the
+    /// underlying logging filter so that flushed buffer-range records can reach your sinks. When
+    /// <c>true</c> (the default), a catch-all filter rule at <see cref="BufferLevel" /> is appended
+    /// as the last (and therefore winning) <em>no-category</em> rule, and the minimum level is
+    /// lowered to <see cref="BufferLevel" /> if it was higher.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This wins over a configuration-bound <c>Logging:LogLevel:Default</c> rule, but it does
+    /// <em>not</em> override more specific category- or provider-scoped rules (for example
+    /// <c>Logging:LogLevel:MyApp</c> or <c>Logging:Console:LogLevel:Default</c>); dumps for those
+    /// categories remain filtered, and the buffering logger emits a one-time warning when it detects
+    /// this.
+    /// </para>
+    /// <para>
+    /// Because the rule is level-based, lowering the effective default filter also makes
+    /// passthrough-band records (at or above <see cref="PassthroughLevel" />) visible live where a
+    /// higher configured default level would have suppressed them. Set this to <c>false</c> if you
+    /// need to control the underlying filter yourself; in that case you must ensure a filter rule at
+    /// <see cref="BufferLevel" /> applies to the buffered categories, otherwise dumped context is
+    /// discarded by the inner logger's filtering.
+    /// </para>
+    /// </remarks>
+    public bool ConfigureUnderlyingFilter { get; set; } = true;
+
+    /// <summary>
+    /// Validates that the configured thresholds satisfy the required invariant.
+    /// </summary>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Any threshold is <see cref="LogLevel.None" />, or the invariant
+    /// <c>BufferLevel &lt;= PassthroughLevel &lt;= FlushLevel</c> is violated.
+    /// </exception>
+    public void Validate()
+    {
+        EnsureReal(BufferLevel, nameof(BufferLevel));
+        EnsureReal(PassthroughLevel, nameof(PassthroughLevel));
+        EnsureReal(FlushLevel, nameof(FlushLevel));
+
+        if (BufferLevel > PassthroughLevel)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(PassthroughLevel),
+                PassthroughLevel,
+                $"{nameof(PassthroughLevel)} ({PassthroughLevel}) must be greater than or equal to {nameof(BufferLevel)} ({BufferLevel}).");
+        }
+
+        if (PassthroughLevel > FlushLevel)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(FlushLevel),
+                FlushLevel,
+                $"{nameof(FlushLevel)} ({FlushLevel}) must be greater than or equal to {nameof(PassthroughLevel)} ({PassthroughLevel}).");
+        }
+    }
+
+    private static void EnsureReal(LogLevel level, string name)
+    {
+        if (level == LogLevel.None)
+        {
+            throw new ArgumentOutOfRangeException(name, level, $"{name} cannot be {nameof(LogLevel.None)}.");
+        }
+    }
+}

--- a/src/JamesConsulting/Logging/BufferingLoggerServiceCollectionExtensions.cs
+++ b/src/JamesConsulting/Logging/BufferingLoggerServiceCollectionExtensions.cs
@@ -1,0 +1,131 @@
+﻿using System;
+using System.Linq;
+using JamesConsulting.Internal;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace JamesConsulting.Logging;
+
+/// <summary>
+/// Dependency-injection helpers that enable buffering ("dump-on-error") logging by decorating the
+/// registered <see cref="ILoggerFactory" />.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Buffering works by holding back low-level records and only emitting them when an error triggers
+/// a flush. For flushed records to reach your sinks, a filter <em>rule</em> at your
+/// <see cref="BufferingLoggerOptions.BufferLevel" /> must apply to the buffered categories. A plain
+/// <c>SetMinimumLevel(LogLevel.Trace)</c> is not enough, because a configuration-provided rule such
+/// as <c>Logging:LogLevel:Default</c> takes precedence over the minimum level. By default
+/// <see cref="BufferingLoggerOptions.ConfigureUnderlyingFilter" /> is enabled, so this method
+/// appends a winning no-category filter rule at <see cref="BufferingLoggerOptions.BufferLevel" /> for
+/// you. Note this only beats the no-category <c>Default</c> rule, not more specific category- or
+/// provider-scoped rules, and (being level-based) it also surfaces passthrough-band records that a
+/// higher configured default would have hidden — see
+/// <see cref="BufferingLoggerOptions.ConfigureUnderlyingFilter" />. The buffering logger still
+/// suppresses live emission of records below
+/// <see cref="BufferingLoggerOptions.PassthroughLevel" />, so your sinks stay quiet until a flush
+/// occurs.
+/// </para>
+/// </remarks>
+public static class BufferingLoggerServiceCollectionExtensions
+{
+    /// <summary>
+    /// Decorates the registered <see cref="ILoggerFactory" /> so that every logger buffers low-level
+    /// records and dumps them on error. Call after logging has been registered (for example after
+    /// <c>AddLogging</c>). This call is idempotent: if buffering has already been added, subsequent
+    /// calls are ignored and the first registration's options are kept.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="configure">An optional callback to configure <see cref="BufferingLoggerOptions" />.</param>
+    /// <returns>The same <paramref name="services" /> instance for chaining.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="services" /> is <c>null</c>.</exception>
+    /// <exception cref="InvalidOperationException">No <see cref="ILoggerFactory" /> has been registered yet.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">The configured options fail validation.</exception>
+    public static IServiceCollection AddBufferingLogging(
+        this IServiceCollection services,
+        Action<BufferingLoggerOptions>? configure = null)
+    {
+        Guard.NotNull(services);
+
+        var options = new BufferingLoggerOptions();
+        configure?.Invoke(options);
+        options.Validate();
+
+        if (services.Any(d => d.ServiceType == typeof(BufferingLoggingMarker)))
+        {
+            // Idempotent: a previous AddBufferingLogging call already decorated the factory. Decorating
+            // again would nest BufferingLoggers and replay buffered records through a second buffer.
+            // The first registration wins.
+            return services;
+        }
+
+        var descriptor = services.LastOrDefault(d => d.ServiceType == typeof(ILoggerFactory));
+        if (descriptor is null)
+        {
+            throw new InvalidOperationException(
+                "AddBufferingLogging requires logging to be registered first. Call AddLogging (or services.AddLogging) before AddBufferingLogging.");
+        }
+
+        services.Remove(descriptor);
+        services.Add(new ServiceDescriptor(
+            typeof(ILoggerFactory),
+            provider => new BufferingLoggerFactory(ResolveInner(provider, descriptor), options),
+            descriptor.Lifetime));
+        services.Add(new ServiceDescriptor(typeof(BufferingLoggingMarker), new BufferingLoggingMarker()));
+
+        if (options.ConfigureUnderlyingFilter)
+        {
+            var bufferLevel = options.BufferLevel;
+
+            // Lower the underlying logging filter so flushed buffer-range records can reach sinks.
+            // PostConfigure runs after every Configure callback (including configuration binding of
+            // Logging:LogLevel sections), so our catch-all rule is appended last and therefore wins
+            // the "take the last matching rule" tie-break. SetMinimumLevel/MinLevel alone is bypassed
+            // whenever a matching rule (e.g. a bound Default rule) exists.
+            services.PostConfigure<LoggerFilterOptions>(filterOptions =>
+            {
+                if (filterOptions.MinLevel > bufferLevel)
+                {
+                    filterOptions.MinLevel = bufferLevel;
+                }
+
+                filterOptions.Rules.Add(new LoggerFilterRule(
+                    providerName: null,
+                    categoryName: null,
+                    logLevel: bufferLevel,
+                    filter: null));
+            });
+        }
+
+        return services;
+    }
+
+    private static ILoggerFactory ResolveInner(IServiceProvider provider, ServiceDescriptor descriptor)
+    {
+        if (descriptor.ImplementationInstance is ILoggerFactory instance)
+        {
+            return instance;
+        }
+
+        if (descriptor.ImplementationFactory is not null)
+        {
+            return (ILoggerFactory)descriptor.ImplementationFactory(provider);
+        }
+
+        if (descriptor.ImplementationType is not null)
+        {
+            return (ILoggerFactory)ActivatorUtilities.CreateInstance(provider, descriptor.ImplementationType);
+        }
+
+        throw new InvalidOperationException("Unable to resolve the inner ILoggerFactory to decorate.");
+    }
+}
+
+/// <summary>
+/// A marker registered in the service collection to make <c>AddBufferingLogging</c> idempotent, so
+/// repeated calls do not nest buffering decorators.
+/// </summary>
+internal sealed class BufferingLoggingMarker
+{
+}

--- a/src/JamesConsulting/Logging/BufferingLoggerServiceCollectionExtensions.cs
+++ b/src/JamesConsulting/Logging/BufferingLoggerServiceCollectionExtensions.cs
@@ -12,20 +12,13 @@ namespace JamesConsulting.Logging;
 /// </summary>
 /// <remarks>
 /// <para>
-/// Buffering works by holding back low-level records and only emitting them when an error triggers
-/// a flush. For flushed records to reach your sinks, a filter <em>rule</em> at your
-/// <see cref="BufferingLoggerOptions.BufferLevel" /> must apply to the buffered categories. A plain
-/// <c>SetMinimumLevel(LogLevel.Trace)</c> is not enough, because a configuration-provided rule such
-/// as <c>Logging:LogLevel:Default</c> takes precedence over the minimum level. By default
-/// <see cref="BufferingLoggerOptions.ConfigureUnderlyingFilter" /> is enabled, so this method
-/// appends a winning no-category filter rule at <see cref="BufferingLoggerOptions.BufferLevel" /> for
-/// you. Note this only beats the no-category <c>Default</c> rule, not more specific category- or
-/// provider-scoped rules, and (being level-based) it also surfaces passthrough-band records that a
-/// higher configured default would have hidden — see
-/// <see cref="BufferingLoggerOptions.ConfigureUnderlyingFilter" />. The buffering logger still
-/// suppresses live emission of records below
-/// <see cref="BufferingLoggerOptions.PassthroughLevel" />, so your sinks stay quiet until a flush
-/// occurs.
+/// Buffering leaves your host's live logging configuration (for example <c>Logging:LogLevel</c>)
+/// untouched and authoritative: records that configuration would write are written live exactly as
+/// before. Low-level records below the live threshold are held back and only emitted when an error
+/// triggers a flush, at which point the buffered context — and the triggering record — are replayed
+/// <em>directly</em> to the registered logging providers, bypassing the
+/// Microsoft.Extensions.Logging factory filters. That direct replay is why no extra filter
+/// configuration is required for flushed records to reach your sinks.
 /// </para>
 /// </remarks>
 public static class BufferingLoggerServiceCollectionExtensions
@@ -48,17 +41,18 @@ public static class BufferingLoggerServiceCollectionExtensions
     {
         Guard.NotNull(services);
 
-        var options = new BufferingLoggerOptions();
-        configure?.Invoke(options);
-        options.Validate();
-
         if (services.Any(d => d.ServiceType == typeof(BufferingLoggingMarker)))
         {
             // Idempotent: a previous AddBufferingLogging call already decorated the factory. Decorating
             // again would nest BufferingLoggers and replay buffered records through a second buffer.
-            // The first registration wins.
+            // The first registration wins, so subsequent calls are ignored before any options are
+            // configured or validated.
             return services;
         }
+
+        var options = new BufferingLoggerOptions();
+        configure?.Invoke(options);
+        options.Validate();
 
         var descriptor = services.LastOrDefault(d => d.ServiceType == typeof(ILoggerFactory));
         if (descriptor is null)
@@ -70,33 +64,12 @@ public static class BufferingLoggerServiceCollectionExtensions
         services.Remove(descriptor);
         services.Add(new ServiceDescriptor(
             typeof(ILoggerFactory),
-            provider => new BufferingLoggerFactory(ResolveInner(provider, descriptor), options),
+            provider => new BufferingLoggerFactory(
+                ResolveInner(provider, descriptor),
+                provider.GetServices<ILoggerProvider>(),
+                options),
             descriptor.Lifetime));
         services.Add(new ServiceDescriptor(typeof(BufferingLoggingMarker), new BufferingLoggingMarker()));
-
-        if (options.ConfigureUnderlyingFilter)
-        {
-            var bufferLevel = options.BufferLevel;
-
-            // Lower the underlying logging filter so flushed buffer-range records can reach sinks.
-            // PostConfigure runs after every Configure callback (including configuration binding of
-            // Logging:LogLevel sections), so our catch-all rule is appended last and therefore wins
-            // the "take the last matching rule" tie-break. SetMinimumLevel/MinLevel alone is bypassed
-            // whenever a matching rule (e.g. a bound Default rule) exists.
-            services.PostConfigure<LoggerFilterOptions>(filterOptions =>
-            {
-                if (filterOptions.MinLevel > bufferLevel)
-                {
-                    filterOptions.MinLevel = bufferLevel;
-                }
-
-                filterOptions.Rules.Add(new LoggerFilterRule(
-                    providerName: null,
-                    categoryName: null,
-                    logLevel: bufferLevel,
-                    filter: null));
-            });
-        }
 
         return services;
     }

--- a/src/JamesConsulting/Logging/BufferingLoggingBuilderExtensions.cs
+++ b/src/JamesConsulting/Logging/BufferingLoggingBuilderExtensions.cs
@@ -11,9 +11,10 @@ public static class BufferingLoggingBuilderExtensions
 {
     /// <summary>
     /// Enables buffering ("dump-on-error") logging by decorating the registered
-    /// <see cref="ILoggerFactory" />. By default the underlying logging filter is lowered for you
-    /// (see <see cref="BufferingLoggerOptions.ConfigureUnderlyingFilter" />) so that flushed records
-    /// reach your sinks.
+    /// <see cref="ILoggerFactory" />. Your host's live logging configuration stays authoritative;
+    /// records below the live threshold are buffered and, on an error inside a
+    /// <see cref="LogBufferScope" />, replayed directly to the registered providers so no extra
+    /// filter configuration is needed for the dump to reach your sinks.
     /// </summary>
     /// <param name="builder">The logging builder.</param>
     /// <param name="configure">An optional callback to configure <see cref="BufferingLoggerOptions" />.</param>
@@ -24,12 +25,12 @@ public static class BufferingLoggingBuilderExtensions
     /// services.AddLogging(logging =>
     /// {
     ///     logging.AddConsole();
-    ///     // AddBufferingLogging lowers the underlying filter to BufferLevel by default, so a
-    ///     // separate SetMinimumLevel/filter rule is not required for the dump to reach sinks.
+    ///     // The host's Logging:LogLevel still controls live logging. BufferLevel sets how deep the
+    ///     // buffer captures; FlushLevel triggers the dump. On error the buffered context is replayed
+    ///     // directly to the providers, bypassing the MEL factory filters.
     ///     logging.AddBufferingLogging(o =>
     ///     {
     ///         o.BufferLevel = LogLevel.Trace;
-    ///         o.PassthroughLevel = LogLevel.Information;
     ///         o.FlushLevel = LogLevel.Error;
     ///     });
     /// });

--- a/src/JamesConsulting/Logging/BufferingLoggingBuilderExtensions.cs
+++ b/src/JamesConsulting/Logging/BufferingLoggingBuilderExtensions.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using JamesConsulting.Internal;
+using Microsoft.Extensions.Logging;
+
+namespace JamesConsulting.Logging;
+
+/// <summary>
+/// <see cref="ILoggingBuilder" /> helpers that enable buffering ("dump-on-error") logging.
+/// </summary>
+public static class BufferingLoggingBuilderExtensions
+{
+    /// <summary>
+    /// Enables buffering ("dump-on-error") logging by decorating the registered
+    /// <see cref="ILoggerFactory" />. By default the underlying logging filter is lowered for you
+    /// (see <see cref="BufferingLoggerOptions.ConfigureUnderlyingFilter" />) so that flushed records
+    /// reach your sinks.
+    /// </summary>
+    /// <param name="builder">The logging builder.</param>
+    /// <param name="configure">An optional callback to configure <see cref="BufferingLoggerOptions" />.</param>
+    /// <returns>The same <paramref name="builder" /> instance for chaining.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="builder" /> is <c>null</c>.</exception>
+    /// <example>
+    /// <code>
+    /// services.AddLogging(logging =>
+    /// {
+    ///     logging.AddConsole();
+    ///     // AddBufferingLogging lowers the underlying filter to BufferLevel by default, so a
+    ///     // separate SetMinimumLevel/filter rule is not required for the dump to reach sinks.
+    ///     logging.AddBufferingLogging(o =>
+    ///     {
+    ///         o.BufferLevel = LogLevel.Trace;
+    ///         o.PassthroughLevel = LogLevel.Information;
+    ///         o.FlushLevel = LogLevel.Error;
+    ///     });
+    /// });
+    /// </code>
+    /// </example>
+    public static ILoggingBuilder AddBufferingLogging(
+        this ILoggingBuilder builder,
+        Action<BufferingLoggerOptions>? configure = null)
+    {
+        Guard.NotNull(builder);
+        builder.Services.AddBufferingLogging(configure);
+        return builder;
+    }
+}

--- a/src/JamesConsulting/Logging/LogBuffer.cs
+++ b/src/JamesConsulting/Logging/LogBuffer.cs
@@ -55,12 +55,21 @@ public static class LogBuffer
     /// Restores the previous ambient scope when <paramref name="scope" /> is disposed. Uses a
     /// best-effort, last-in-first-out restore: the ambient slot is only changed when it still refers
     /// to <paramref name="scope" />, so out-of-order disposal does not clobber an unrelated scope.
+    /// Any ancestors that were themselves disposed out of order are skipped so the ambient slot never
+    /// points at a disposed scope.
     /// </summary>
     internal static void Restore(LogBufferScope scope, LogBufferScope? previous)
     {
-        if (ReferenceEquals(CurrentScope.Value, scope))
+        if (!ReferenceEquals(CurrentScope.Value, scope))
         {
-            CurrentScope.Value = previous;
+            return;
         }
+
+        while (previous is not null && previous.IsDisposed)
+        {
+            previous = previous.PreviousScope;
+        }
+
+        CurrentScope.Value = previous;
     }
 }

--- a/src/JamesConsulting/Logging/LogBuffer.cs
+++ b/src/JamesConsulting/Logging/LogBuffer.cs
@@ -1,0 +1,66 @@
+﻿using System.Threading;
+
+namespace JamesConsulting.Logging;
+
+/// <summary>
+/// Entry point for starting and accessing the ambient <see cref="LogBufferScope" /> used by the
+/// buffering logger. Wrap a logical operation (an HTTP request, a message handler, a background job)
+/// in a scope so that low-level diagnostic logs are captured and only emitted if the operation
+/// fails.
+/// </summary>
+/// <example>
+/// Buffer Debug/Trace logs for the duration of an operation and dump them on error:
+/// <code>
+/// using (LogBuffer.BeginScope())
+/// {
+///     logger.LogDebug("Loading order {OrderId}", orderId);   // buffered
+///     logger.LogInformation("Order {OrderId} loaded", orderId); // written live
+///     // ... if an error is logged here, the buffered Debug record is dumped first ...
+///     logger.LogError(ex, "Failed to process order {OrderId}", orderId);
+/// }
+/// </code>
+/// </example>
+public static class LogBuffer
+{
+    private static readonly AsyncLocal<LogBufferScope?> CurrentScope = new();
+
+    /// <summary>
+    /// Gets the scope currently active on this asynchronous flow, or <c>null</c> if none is active.
+    /// </summary>
+    public static LogBufferScope? Current => CurrentScope.Value;
+
+    /// <summary>
+    /// Starts a new buffering scope using <see cref="LogBufferScope.DefaultCapacity" /> and makes it
+    /// the ambient scope for the current asynchronous flow.
+    /// </summary>
+    /// <returns>The new scope. Dispose it (preferably with <c>using</c>) to end buffering.</returns>
+    public static LogBufferScope BeginScope() => BeginScope(LogBufferScope.DefaultCapacity);
+
+    /// <summary>
+    /// Starts a new buffering scope with the specified ring-buffer capacity and makes it the ambient
+    /// scope for the current asynchronous flow. Scopes may be nested; disposing a nested scope
+    /// restores its parent.
+    /// </summary>
+    /// <param name="capacity">The maximum number of records the scope buffers before the oldest are dropped.</param>
+    /// <returns>The new scope. Dispose it (preferably with <c>using</c>) to end buffering.</returns>
+    /// <exception cref="System.ArgumentOutOfRangeException"><paramref name="capacity" /> is not greater than zero.</exception>
+    public static LogBufferScope BeginScope(int capacity)
+    {
+        var scope = new LogBufferScope(CurrentScope.Value, capacity);
+        CurrentScope.Value = scope;
+        return scope;
+    }
+
+    /// <summary>
+    /// Restores the previous ambient scope when <paramref name="scope" /> is disposed. Uses a
+    /// best-effort, last-in-first-out restore: the ambient slot is only changed when it still refers
+    /// to <paramref name="scope" />, so out-of-order disposal does not clobber an unrelated scope.
+    /// </summary>
+    internal static void Restore(LogBufferScope scope, LogBufferScope? previous)
+    {
+        if (ReferenceEquals(CurrentScope.Value, scope))
+        {
+            CurrentScope.Value = previous;
+        }
+    }
+}

--- a/src/JamesConsulting/Logging/LogBufferEnqueueResult.cs
+++ b/src/JamesConsulting/Logging/LogBufferEnqueueResult.cs
@@ -11,8 +11,9 @@ internal enum LogBufferEnqueueResult
     Enqueued,
 
     /// <summary>
-    /// The scope was already flushed and buffering is suspended; the caller should emit the record
-    /// live instead of buffering it.
+    /// The scope was already flushed and buffering is suspended, so the record was not buffered. The
+    /// host's live configuration stays authoritative for it; because it is below the live threshold
+    /// it is effectively dropped.
     /// </summary>
     AlreadyFlushed,
 

--- a/src/JamesConsulting/Logging/LogBufferEnqueueResult.cs
+++ b/src/JamesConsulting/Logging/LogBufferEnqueueResult.cs
@@ -1,0 +1,23 @@
+﻿namespace JamesConsulting.Logging;
+
+/// <summary>
+/// The outcome of attempting to enqueue a record into a <see cref="LogBufferScope" />.
+/// </summary>
+internal enum LogBufferEnqueueResult
+{
+    /// <summary>
+    /// The record was buffered.
+    /// </summary>
+    Enqueued,
+
+    /// <summary>
+    /// The scope was already flushed and buffering is suspended; the caller should emit the record
+    /// live instead of buffering it.
+    /// </summary>
+    AlreadyFlushed,
+
+    /// <summary>
+    /// The scope was disposed; the record was dropped.
+    /// </summary>
+    Disposed,
+}

--- a/src/JamesConsulting/Logging/LogBufferScope.cs
+++ b/src/JamesConsulting/Logging/LogBufferScope.cs
@@ -9,7 +9,8 @@ namespace JamesConsulting.Logging;
 /// (see <see cref="LogBuffer.BeginScope(int)" />), the buffering logger captures buffer-range
 /// records into it instead of writing them. When the scope is flushed — either automatically by a
 /// record at or above the configured flush level, or manually via <see cref="Flush" /> — every
-/// captured record is emitted to its originating logger. Records are replayed in the order they were
+/// captured record is replayed directly to the registered logging providers, bypassing the
+/// Microsoft.Extensions.Logging factory-level filters. Records are replayed in the order they were
 /// logged within a single logical flow; ordering is best-effort under any concurrent logging on the
 /// scope (for example a second thread flushing or writing live while a replay is in progress).
 /// </summary>
@@ -60,6 +61,12 @@ public sealed class LogBufferScope : IDisposable
     public int Capacity => buffer.Length;
 
     /// <summary>
+    /// Gets the scope that was ambient when this scope was started, restored when this scope is
+    /// disposed. <c>null</c> for a root scope.
+    /// </summary>
+    internal LogBufferScope? PreviousScope => previous;
+
+    /// <summary>
     /// Gets the number of records currently held in the buffer.
     /// </summary>
     public int Count
@@ -74,12 +81,14 @@ public sealed class LogBufferScope : IDisposable
     }
 
     /// <summary>
-    /// Gets a value indicating whether this scope has been flushed, meaning subsequent buffer-range
-    /// records are written live when <see cref="BufferingLoggerOptions.SuspendBufferingAfterFlush" />
-    /// is enabled. Set by an error-triggered flush (even when the buffer was empty) and by a manual
-    /// <see cref="Flush" /> that actually dumped records; an empty manual <see cref="Flush" /> leaves
-    /// it unset. Ancestor scopes dumped for context by a nested error are <em>not</em> marked
-    /// flushed.
+    /// Gets a value indicating whether this scope has been flushed. When
+    /// <see cref="BufferingLoggerOptions.SuspendBufferingAfterFlush" /> is enabled, buffering is
+    /// suspended once this is set, so subsequent buffer-range records are no longer captured; they
+    /// are emitted only if the host's live configuration (which stays authoritative) would write
+    /// them, and are otherwise dropped. Set by an error-triggered flush (even when the buffer was
+    /// empty) and by a manual <see cref="Flush" /> that actually dumped records; an empty manual
+    /// <see cref="Flush" /> leaves it unset. Ancestor scopes dumped for context by a nested error are
+    /// <em>not</em> marked flushed.
     /// </summary>
     public bool IsFlushed
     {
@@ -107,9 +116,10 @@ public sealed class LogBufferScope : IDisposable
     }
 
     /// <summary>
-    /// Emits every buffered record, in the order it was logged, to its originating logger, then
-    /// clears the buffer. When records are dumped the scope is marked flushed (suspending buffering
-    /// for the remainder of the scope when
+    /// Replays every buffered record, in the order it was logged, directly to the registered logging
+    /// providers (bypassing the Microsoft.Extensions.Logging factory-level filters), then clears the
+    /// buffer. When records are dumped the scope is marked flushed (suspending buffering for the
+    /// remainder of the scope when
     /// <see cref="BufferingLoggerOptions.SuspendBufferingAfterFlush" /> is enabled); a manual flush
     /// that finds no buffered records is a no-op and does <em>not</em> suspend buffering, so a
     /// defensive <see cref="Flush" /> cannot silently disable buffering for the rest of the scope.
@@ -199,9 +209,11 @@ public sealed class LogBufferScope : IDisposable
 
             if (isFlushed && suspendAfterFlush)
             {
-                // The scope was flushed (possibly concurrently) and buffering is suspended: the
-                // caller must emit this record live instead. Decided under the lock so it cannot
-                // race with a concurrent Flush.
+                // The scope was flushed (possibly concurrently) and buffering is suspended, so this
+                // record is not captured. Emission is left to the host's authoritative live
+                // configuration, which already declined this below-threshold record, so it is
+                // effectively dropped. Decided under the lock so it cannot race with a concurrent
+                // Flush.
                 return LogBufferEnqueueResult.AlreadyFlushed;
             }
 

--- a/src/JamesConsulting/Logging/LogBufferScope.cs
+++ b/src/JamesConsulting/Logging/LogBufferScope.cs
@@ -1,0 +1,247 @@
+﻿using System;
+using JamesConsulting.Internal;
+using Microsoft.Extensions.Logging;
+
+namespace JamesConsulting.Logging;
+
+/// <summary>
+/// A bounded, thread-safe, per-operation buffer of low-level log records. While a scope is active
+/// (see <see cref="LogBuffer.BeginScope(int)" />), the buffering logger captures buffer-range
+/// records into it instead of writing them. When the scope is flushed — either automatically by a
+/// record at or above the configured flush level, or manually via <see cref="Flush" /> — every
+/// captured record is emitted to its originating logger. Records are replayed in the order they were
+/// logged within a single logical flow; ordering is best-effort under any concurrent logging on the
+/// scope (for example a second thread flushing or writing live while a replay is in progress).
+/// </summary>
+/// <remarks>
+/// <para>
+/// The buffer is a ring buffer: once <c>capacity</c> records are held, the oldest record is dropped
+/// to make room for the newest. Choose a capacity large enough to hold the diagnostic context you
+/// want to see leading up to a failure.
+/// </para>
+/// <para>
+/// Scopes are ambient and flow with <see cref="System.Threading.AsyncLocal{T}" />, so they cross
+/// <c>await</c> points and <see cref="System.Threading.Tasks.Task" /> continuations within the same
+/// logical operation. Always dispose a scope (preferably with <c>using</c>) at the end of the
+/// operation to restore the previous ambient scope and stop capturing.
+/// </para>
+/// <para>
+/// Buffered records do not capture <see cref="ILogger.BeginScope{TState}" /> state; logging scopes
+/// active at capture time may already be disposed when the record is replayed. This matches the
+/// behaviour of the built-in .NET log buffering.
+/// </para>
+/// </remarks>
+public sealed class LogBufferScope : IDisposable
+{
+    /// <summary>
+    /// The default ring-buffer capacity used by <see cref="LogBuffer.BeginScope()" /> when no
+    /// explicit capacity is supplied.
+    /// </summary>
+    public const int DefaultCapacity = 1000;
+
+    private readonly object gate = new();
+    private readonly BufferedLogEntry?[] buffer;
+    private readonly LogBufferScope? previous;
+    private int head;
+    private int count;
+    private bool isFlushed;
+    private bool isDisposed;
+
+    internal LogBufferScope(LogBufferScope? previous, int capacity)
+    {
+        Guard.StrictlyPositive(capacity);
+        this.previous = previous;
+        buffer = new BufferedLogEntry?[capacity];
+    }
+
+    /// <summary>
+    /// Gets the maximum number of records this scope can hold before the oldest are dropped.
+    /// </summary>
+    public int Capacity => buffer.Length;
+
+    /// <summary>
+    /// Gets the number of records currently held in the buffer.
+    /// </summary>
+    public int Count
+    {
+        get
+        {
+            lock (gate)
+            {
+                return count;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether this scope has been flushed, meaning subsequent buffer-range
+    /// records are written live when <see cref="BufferingLoggerOptions.SuspendBufferingAfterFlush" />
+    /// is enabled. Set by an error-triggered flush (even when the buffer was empty) and by a manual
+    /// <see cref="Flush" /> that actually dumped records; an empty manual <see cref="Flush" /> leaves
+    /// it unset. Ancestor scopes dumped for context by a nested error are <em>not</em> marked
+    /// flushed.
+    /// </summary>
+    public bool IsFlushed
+    {
+        get
+        {
+            lock (gate)
+            {
+                return isFlushed;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether this scope has been disposed.
+    /// </summary>
+    public bool IsDisposed
+    {
+        get
+        {
+            lock (gate)
+            {
+                return isDisposed;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Emits every buffered record, in the order it was logged, to its originating logger, then
+    /// clears the buffer. When records are dumped the scope is marked flushed (suspending buffering
+    /// for the remainder of the scope when
+    /// <see cref="BufferingLoggerOptions.SuspendBufferingAfterFlush" /> is enabled); a manual flush
+    /// that finds no buffered records is a no-op and does <em>not</em> suspend buffering, so a
+    /// defensive <see cref="Flush" /> cannot silently disable buffering for the rest of the scope.
+    /// Safe to call multiple times. Exceptions thrown while replaying an individual record are
+    /// swallowed so that one faulty record cannot prevent the rest — or the triggering error — from
+    /// being written.
+    /// </summary>
+    public void Flush() => FlushCore(suspendOnDump: true, suspendIfEmpty: false);
+
+    /// <summary>
+    /// Dumps the accrued context on the error-trigger path: ancestor scopes are dumped oldest-first
+    /// for chronological context (their buffered records are consumed by this dump, but the ancestors
+    /// are <em>not</em> marked flushed, so they keep buffering afterward and are not suspended), then
+    /// this scope is dumped and always marked flushed — even when its buffer was empty — so an error
+    /// suspends buffering for the remainder of this scope.
+    /// </summary>
+    internal void FlushForError()
+    {
+        previous?.DumpAncestorChain();
+        FlushCore(suspendOnDump: true, suspendIfEmpty: true);
+    }
+
+    private void DumpAncestorChain()
+    {
+        previous?.DumpAncestorChain();
+        FlushCore(suspendOnDump: false, suspendIfEmpty: false);
+    }
+
+    private void FlushCore(bool suspendOnDump, bool suspendIfEmpty)
+    {
+        BufferedLogEntry[] snapshot;
+        lock (gate)
+        {
+            if (count == 0)
+            {
+                // Mark flushed (atomically, under the same lock) only when the caller wants an empty
+                // flush to suspend — i.e. the error path. This closes the gap where a concurrent
+                // enqueue between a separate flush and mark could be orphaned.
+                if (suspendIfEmpty && !isDisposed)
+                {
+                    isFlushed = true;
+                }
+
+                return;
+            }
+
+            if (suspendOnDump)
+            {
+                isFlushed = true;
+            }
+
+            snapshot = new BufferedLogEntry[count];
+            for (var i = 0; i < count; i++)
+            {
+                snapshot[i] = buffer[(head + i) % buffer.Length]!;
+                buffer[(head + i) % buffer.Length] = null;
+            }
+
+            head = 0;
+            count = 0;
+        }
+
+        // Replay outside the lock to avoid deadlocks/contention if a sink re-enters logging.
+        foreach (var entry in snapshot)
+        {
+            try
+            {
+                entry.Replay();
+            }
+            catch
+            {
+                // Best-effort: a single faulty sink/record must not break the dump or suppress the
+                // triggering error. The buffering logger is diagnostic infrastructure and never
+                // throws back into the caller's logging path.
+            }
+        }
+    }
+
+    internal LogBufferEnqueueResult TryEnqueue(BufferedLogEntry entry, bool suspendAfterFlush)
+    {
+        lock (gate)
+        {
+            if (isDisposed)
+            {
+                return LogBufferEnqueueResult.Disposed;
+            }
+
+            if (isFlushed && suspendAfterFlush)
+            {
+                // The scope was flushed (possibly concurrently) and buffering is suspended: the
+                // caller must emit this record live instead. Decided under the lock so it cannot
+                // race with a concurrent Flush.
+                return LogBufferEnqueueResult.AlreadyFlushed;
+            }
+
+            if (count == buffer.Length)
+            {
+                // Drop the oldest record to make room (ring buffer).
+                buffer[head] = null;
+                head = (head + 1) % buffer.Length;
+                count--;
+            }
+
+            buffer[(head + count) % buffer.Length] = entry;
+            count++;
+            return LogBufferEnqueueResult.Enqueued;
+        }
+    }
+
+    /// <summary>
+    /// Disposes the scope, discarding any records that were buffered but never flushed, and restores
+    /// the previously active ambient scope.
+    /// </summary>
+    public void Dispose()
+    {
+        lock (gate)
+        {
+            if (isDisposed)
+            {
+                return;
+            }
+
+            isDisposed = true;
+            for (var i = 0; i < count; i++)
+            {
+                buffer[(head + i) % buffer.Length] = null;
+            }
+
+            head = 0;
+            count = 0;
+        }
+
+        LogBuffer.Restore(this, previous);
+    }
+}

--- a/src/JamesConsulting/Logging/ProviderReplayLogger.cs
+++ b/src/JamesConsulting/Logging/ProviderReplayLogger.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using System.Collections.Concurrent;
+using Microsoft.Extensions.Logging;
+
+namespace JamesConsulting.Logging;
+
+/// <summary>
+/// An <see cref="ILogger" /> used as the replay target for a buffering dump. It fans a record out to
+/// every registered <see cref="ILoggerProvider" />'s logger for a single category, writing
+/// <em>directly</em> to the provider loggers so the dump bypasses the Microsoft.Extensions.Logging
+/// factory-level filters (category, provider, and <c>Logging:LogLevel</c> rules). This is what lets
+/// flushed buffer-range records reach the sinks even though the live configuration suppressed them.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The provider set is read from a live snapshot on every write, so providers added to the factory
+/// after this logger was created are still included in later dumps. Per-provider loggers are cached
+/// by provider instance; under concurrent first-time dumps a provider's
+/// <see cref="ILoggerProvider.CreateLogger" /> may run more than once and the extra result is
+/// discarded, which is harmless for the in-box providers but worth noting if a provider's
+/// <c>CreateLogger</c> is expensive or side-effecting. The provider instances are owned by the
+/// underlying <see cref="ILoggerFactory" />/DI container, so this type never disposes them.
+/// </para>
+/// <para>
+/// Records are written outside any buffering decision, so a single faulty provider cannot break the
+/// rest of the dump: each provider write is guarded and its exceptions are swallowed.
+/// </para>
+/// </remarks>
+internal sealed class ProviderReplayLogger : ILogger
+{
+    private readonly string category;
+    private readonly Func<ILoggerProvider[]> providersSnapshot;
+    private readonly ConcurrentDictionary<ILoggerProvider, ILogger> loggers = new();
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ProviderReplayLogger" /> class.
+    /// </summary>
+    /// <param name="category">The category name the replayed records belong to.</param>
+    /// <param name="providersSnapshot">
+    /// A callback returning the current set of providers to fan out to. Invoked on every write so
+    /// late-added providers are picked up.
+    /// </param>
+    public ProviderReplayLogger(string category, Func<ILoggerProvider[]> providersSnapshot)
+    {
+        this.category = category;
+        this.providersSnapshot = providersSnapshot;
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether the replay target currently has at least one provider to fan
+    /// out to. When <c>false</c> a dump would reach no sink, so the caller can fall back to the inner
+    /// logger for the triggering record rather than lose it.
+    /// </summary>
+    public bool HasSinks => providersSnapshot().Length > 0;
+
+    /// <inheritdoc />
+    public IDisposable? BeginScope<TState>(TState state)
+        where TState : notnull => null;
+
+    /// <inheritdoc />
+    public bool IsEnabled(LogLevel logLevel) => logLevel != LogLevel.None;
+
+    /// <inheritdoc />
+    public void Log<TState>(
+        LogLevel logLevel,
+        EventId eventId,
+        TState state,
+        Exception? exception,
+        Func<TState, Exception?, string> formatter)
+    {
+        foreach (var provider in providersSnapshot())
+        {
+            ILogger logger;
+            try
+            {
+                logger = loggers.GetOrAdd(provider, p => p.CreateLogger(category));
+            }
+            catch
+            {
+                // A provider whose CreateLogger throws cannot participate in the dump; skip it
+                // rather than abort the whole replay.
+                continue;
+            }
+
+            try
+            {
+                logger.Log(logLevel, eventId, state, exception, formatter);
+            }
+            catch
+            {
+                // Best-effort: one faulty sink must not break the dump or suppress the triggering
+                // error. The buffering logger is diagnostic infrastructure and never throws back
+                // into the caller's logging path.
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds `JamesConsulting.Logging`: an `ILogger`/`ILoggerFactory` decorator that **buffers low-level (Debug/Trace) records per `AsyncLocal` scope** and **replays them directly to the registered logging providers when an Error/Critical is logged**. You get the full diagnostic context leading up to a failure, without paying the noise cost the rest of the time.

### The model: host-config-authoritative live, full-replay-on-trigger

Your host's existing live logging configuration (e.g. `Logging:LogLevel:Default`) stays **completely authoritative** for what is written live — buffering never overrides it. On top of that, two thresholds (`BufferLevel ≤ FlushLevel`) drive capture and the dump trigger:

- Records your live configuration would already write are **written live, unchanged**.
- Records **below the live threshold but at or above `BufferLevel`** are captured into the active scope's ring buffer (never written live).
- Records **below `BufferLevel`** are dropped.
- When a record at/above `FlushLevel` (default `Error`) is logged **inside an active scope**, the accrued context is **replayed in full, oldest-first, directly to the registered providers** — bypassing the Microsoft.Extensions.Logging factory-level filters — alongside the triggering record. No trigger → the buffered context is simply discarded as scopes unwind.

Defaults: `BufferLevel = Trace`, `FlushLevel = Error`.

This auto-flush-on-error behavior is the **differentiator over .NET 9's built-in `GlobalLogBuffer`**, which buffers but has **no automatic trigger** (you must call `Flush()` yourself). This fills that gap.

## Design

- **Decorator over the inner provider** — `BufferingLogger`/`BufferingLoggerFactory` wrap whatever logging you already have; sinks are unchanged.
- **Direct-to-providers replay target** — the error dump is fanned out through a `ProviderReplayLogger` that writes straight to the registered providers, so the suppressed low-level context surfaces on error **without any extra filter configuration**. The inner logger remains authoritative for the live-level decision.
- **Ambient buffer** — `LogBuffer` (`AsyncLocal`) + `LogBufferScope`: a bounded, drop-oldest ring buffer. The flushed-vs-enqueue decision is made under the scope lock (race-free).
- **Best-effort flush that never suppresses the error** — on trigger the whole live scope chain is dumped oldest-first (ancestors included for context, and **kept buffering**); only the innermost scope is suspended (configurable via `SuspendBufferingAfterFlush`).
- **DI wiring** — `AddBufferingLogging(...)`, idempotent decoration.

## Key behaviors

- **No extra filter configuration needed.** Because the dump replays **directly to the registered providers** (bypassing the MEL factory filters / `Logging:LogLevel` category rules), a plain `Logging:LogLevel:Default = Information` is all you need for buffered `Debug`/`Trace` to appear on error. One consequence: an error replays the buffered context to **every** registered provider, even one whose own configured level would normally exclude those records.
- **No-providers fallback.** If the replay target reaches no providers (e.g. a custom inner factory whose providers weren't surfaced to the decorator, or a host with no providers registered), the buffered context can't be dumped; the triggering `Error`/`Critical` record then falls back to the inner logger and follows the host's live configuration. In any realistic setup (at least one provider such as `AddConsole()`), the dump reaches every registered sink.
- **Replay fidelity** — object-valued structured properties are frozen to text at log time, so later mutation of those objects can't change what the dump reports; scalars keep their original type.
- **Hardened hot path** — the caller's logging path is guarded against throwing formatters and hostile structured-state enumerators.

## `LogBufferScope` (beyond the Phase-1 global-buffer plan)

`LogBufferScope` is the per-scope ring buffer that makes the "context window" `AsyncLocal` and bounded. It's **purely additive / opt-in**: the default global-buffer path works without callers touching it directly — scopes are managed internally as logging scopes are entered/exited. It's covered by `LogBufferScopeTests` (chain dump ordering, ancestor behavior, suspension, drop-oldest eviction).

## Limitations / caveats (documented honestly in README + options)

- The dump bypasses factory-level filters by design, so it reaches **every** registered provider on error — including ones whose configured level would normally exclude the dumped records.
- With **no logging providers registered**, the buffered context can't be surfaced (only the triggering record falls back to the inner logger).
- **Scopes (`BeginScope`) and `Activity`/trace context are not captured/replayed** in this phase — only the log records themselves.

## Testing

- **196 tests**, green on **net9.0 + net10.0**.
- Clean build, **0 warnings across all 4 TFMs** (netstandard2.0/2.1, net9.0, net10.0).

## Reviews

Two independent rubber-duck reviews (gpt-5.5 + Claude) on the final state — both non-blocking. Their findings (false-positive backstop warning outside a scope; over-broad "reaches no sink" predicate) were resolved in the `c088ea3` refactor, which replaced the earlier filter-rule + backstop-warning approach with the simpler direct-to-providers replay model (host config stays authoritative; no-providers path falls back to the inner logger), plus a precise top-of-band `IsEnabled` check and regression tests.
